### PR TITLE
let Lntxbot have internal transfers correctly handled

### DIFF
--- a/lnbits/wallets/lntxbot.py
+++ b/lnbits/wallets/lntxbot.py
@@ -99,9 +99,9 @@ class LntxbotWallet(Wallet):
             return PaymentResponse(False, None, 0, None, error_message)
 
         data = r.json()
-        checking_id = data["payment_hash"]
-        fee_msat = -data["fee_msat"]
-        preimage = data["payment_preimage"]
+        checking_id = data.get("payment_hash") or "lntxbot_internal_"+str(hash(r))
+        fee_msat = -(data.get("fee_msat") or 0)
+        preimage = data.get("payment_preimage")
         return PaymentResponse(True, checking_id, fee_msat, preimage, None)
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:


### PR DESCRIPTION
Invoices fulfilled internally within lntxbot users (including within one same user) do not respond with any payment_hash or payment_preimage. Still, if the reply has succeeded status it means it has gone through. We can handle the situation by giving a checking_id based on the hash of the response (it will not be directly queriable, but at the same time it needs to be unique in the DB), assign a blank fee to value 0, and leave the preimage blank