### PR TITLE
Add actual fee limit (only lnd for now)

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -158,7 +158,15 @@ async def pay_invoice(
             await internal_invoice_paid.send(internal_checking_id)
         else:
             # actually pay the external invoice
-            payment: PaymentResponse = await WALLET.pay_invoice(payment_request)
+            fee_limit_msat = fee_reserve(invoice.amount_msat)
+            try:
+                payment: PaymentResponse = await WALLET.pay_invoice(
+                    payment_request,
+                    fee_limit_msat=fee_limit_msat
+                )
+            except TypeError:
+                # fee limit not supported by backend
+                payment: PaymentResponse = await WALLET.pay_invoice(payment_request)
             if payment.checking_id:
                 await create_payment(
                     checking_id=payment.checking_id,

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -157,8 +157,10 @@ async def pay_invoice(
 
             await internal_invoice_paid.send(internal_checking_id)
         else:
+            # fees will never exceed 1%, unless that is less than 10 sats
+            max_fee = max(10000, int(invoice.amount_msat * 0.01))
+            fee_limit_msat = min(max_fee, wallet.balance_msat - invoice.amount_msat)
             # actually pay the external invoice
-            fee_limit_msat = fee_reserve(invoice.amount_msat)
             try:
                 payment: PaymentResponse = await WALLET.pay_invoice(
                     payment_request,

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -144,8 +144,11 @@ class LndWallet(Wallet):
         payment_request = str(resp.payment_request)
         return InvoiceResponse(True, checking_id, payment_request, None)
 
-    async def pay_invoice(self, bolt11: str) -> PaymentResponse:
-        resp = self.rpc.send_payment(payment_request=bolt11)
+    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+        resp = self.rpc.send_payment(
+            payment_request=bolt11,
+            fee_limit_msat=fee_limit_msat
+        )
 
         if resp.payment_error:
             return PaymentResponse(False, "", 0, None, resp.payment_error)

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -93,12 +93,15 @@ class LndRestWallet(Wallet):
 
         return InvoiceResponse(True, checking_id, payment_request, None)
 
-    async def pay_invoice(self, bolt11: str) -> PaymentResponse:
+    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient(verify=self.cert) as client:
             r = await client.post(
                 url=f"{self.endpoint}/v1/channels/transactions",
                 headers=self.auth,
-                json={"payment_request": bolt11},
+                json={
+                    "payment_request": bolt11,
+                    "fee_limit": {"fixed_msat": str(fee_limit_msat)},
+                },
                 timeout=180,
             )
 


### PR DESCRIPTION
This sets a hard fee limit for lnd backends. It should entirely prevent negative LNbits wallet balances (obviously for lnd only for now).
Additionally, this makes it possible to sweep the wallet's entire balance, if a 0-fee route can be found.

I haven't done all too extensive testing for this, so it's just a draft PR for now. It would be nice someone could test this more thoroughly, as I probably missed things.