### PR TITLE
Display balance with local currency.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ PORT=5000
 
 LNBITS_ALLOWED_USERS=""
 LNBITS_DEFAULT_WALLET_NAME="LNbits wallet"
+LNBITS_SHOW_FIAT=true
 
 # Database: to use SQLite, specify LNBITS_DATA_FOLDER
 #           to use PostgreSQL, specify LNBITS_DATABASE_URL=postgres://...

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -109,6 +109,7 @@ def register_filters(app: QuartTrio):
     app.jinja_env.globals["SITE_DESCRIPTION"] = app.config["LNBITS_SITE_DESCRIPTION"]
     app.jinja_env.globals["LNBITS_THEME_OPTIONS"] = app.config["LNBITS_THEME_OPTIONS"]
     app.jinja_env.globals["LNBITS_VERSION"] = app.config["LNBITS_COMMIT"]
+    app.jinja_env.globals["LNBITS_SHOW_FIAT"] = app.config["LNBITS_SHOW_FIAT"]
     app.jinja_env.globals["EXTENSIONS"] = get_valid_extensions()
 
 

--- a/lnbits/core/static/js/wallet.js
+++ b/lnbits/core/static/js/wallet.js
@@ -166,6 +166,13 @@ new Vue({
             sortable: true
           },
           {
+            name: 'local',
+            align: 'right',
+            label: 'Amount (local)',
+            field: 'local',
+            sortable: true
+          },
+          {
             name: 'fee',
             align: 'right',
             label: 'Fee (msat)',
@@ -212,6 +219,9 @@ new Vue({
     }
   },
   methods: {
+    formattedValueLocal: function (from_sats) {
+      return LNbits.utils.formatCurrency(from_sats * this.g.localCurrencyRate, this.g.localCurrency)
+    },
     paymentTableRowKey: function (row) {
       return row.payment_hash + row.amount
     },
@@ -234,7 +244,7 @@ new Vue({
       this.receive.paymentHash = null
       this.receive.data.amount = null
       this.receive.data.memo = null
-      this.receive.unit = 'sat'
+      this.receive.unit = this.g.localCurrency
       this.receive.units = this.g.localCurrencies
       this.receive.paymentChecker = null
       this.receive.minMax = [0, 2100000000000000]

--- a/lnbits/core/static/js/wallet.js
+++ b/lnbits/core/static/js/wallet.js
@@ -235,6 +235,7 @@ new Vue({
       this.receive.data.amount = null
       this.receive.data.memo = null
       this.receive.unit = 'sat'
+      this.receive.units = this.g.localCurrencies
       this.receive.paymentChecker = null
       this.receive.minMax = [0, 2100000000000000]
       this.receive.lnurl = null
@@ -649,15 +650,6 @@ new Vue({
   created: function () {
     this.fetchBalance()
     this.fetchPayments()
-
-    LNbits.api
-      .request('GET', '/api/v1/currencies')
-      .then(response => {
-        this.receive.units = ['sat', ...response.data]
-      })
-      .catch(err => {
-        LNbits.utils.notifyApiError(err)
-      })
   },
   mounted: function () {
     // show disclaimer

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -17,6 +17,9 @@
         <h3 class="q-my-none">
           <strong>{% raw %}{{ formattedBalance }}{% endraw %}</strong> sat
         </h3>
+        <h4 class="q-my-none" v-if="g.localCurrency != 'sat'">
+                {% raw %}{{ formattedValueLocal(balance) }}{% endraw %}
+        </h4>
       </q-card-section>
       <div class="row q-pb-md q-px-md q-col-gutter-md">
         <div class="col">
@@ -98,9 +101,11 @@
           <template v-slot:header="props">
             <q-tr :props="props">
               <q-th auto-width></q-th>
-              <q-th v-for="col in props.cols" :key="col.name" :props="props"
-                >{{ col.label }}</q-th
-              >
+              <template v-for="col in props.cols">
+                <q-th v-if="g.localCurrency != 'sat' || col.field != 'local'" :key="col.name" :props="props">
+                    {{ col.field == 'local' ? 'Amount (' + g.localCurrency + ')' : col.label }}
+                </q-th>
+              </template>
             </q-tr>
           </template>
           <template v-slot:body="props">
@@ -143,6 +148,9 @@
               </q-td>
               <q-td auto-width key="sat" :props="props">
                 {{ props.row.fsat }}
+              </q-td>
+              <q-td v-if="g.localCurrency != 'sat'" auto-width key="local" :props="props">
+                {{ formattedValueLocal(props.row.sat) }}
               </q-td>
               <q-td auto-width key="fee" :props="props">
                 {{ props.row.fee }}
@@ -418,7 +426,10 @@
   <q-card class="q-pa-lg q-pt-xl lnbits__dialog-card">
     <div v-if="parse.invoice">
       {% raw %}
-      <h6 class="q-my-none">{{ parse.invoice.fsat }} sat</h6>
+      <h5 class="q-my-none">{{ parse.invoice.fsat }} sat</h6>
+      <h6 class="q-my-none" v-if="g.localCurrency != 'sat'">
+        {{ formattedValueLocal(parse.invoice.sat) }}
+      </h6>
       <q-separator class="q-my-sm"></q-separator>
       <p class="text-wrap">
         <strong>Description:</strong> {{ parse.invoice.description }}<br />

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -31,6 +31,7 @@ LNBITS_ALLOWED_USERS: List[str] = env.list(
 LNBITS_DISABLED_EXTENSIONS: List[str] = env.list(
     "LNBITS_DISABLED_EXTENSIONS", default=[], subcast=str
 )
+LNBITS_SHOW_FIAT = env.bool("LNBITS_SHOW_FIAT", default="false")
 
 LNBITS_SITE_TITLE = env.str("LNBITS_SITE_TITLE", default="LNbits")
 LNBITS_SITE_TAGLINE = env.str(

--- a/lnbits/static/js/base.js
+++ b/lnbits/static/js/base.js
@@ -312,6 +312,7 @@ window.windowMixin = {
         wallet: null,
         payments: [],
         allowedThemes: null
+        localCurrencies: [],
       }
     }
   },
@@ -363,6 +364,15 @@ window.windowMixin = {
     if (window.wallet) {
       this.g.wallet = Object.freeze(window.LNbits.map.wallet(window.wallet))
     }
+
+    LNbits.api
+      .request('GET', '/api/v1/currencies')
+      .then(response => {
+        this.g.localCurrencies = ['sat', ...response.data]
+      })
+      .catch(err => {
+        LNbits.utils.notifyApiError(err)
+      })
     if (window.extensions) {
       var user = this.g.user
       this.g.extensions = Object.freeze(

--- a/lnbits/static/js/base.js
+++ b/lnbits/static/js/base.js
@@ -399,6 +399,9 @@ window.windowMixin = {
     if (currency) {
       this.setLocalCurrency(currency)
     }
+    setInterval(() => {
+      this.setLocalCurrency(this.g.localCurrency)
+    }, 600000)
 
     if (window.extensions) {
       var user = this.g.user

--- a/lnbits/static/js/base.js
+++ b/lnbits/static/js/base.js
@@ -353,6 +353,7 @@ window.windowMixin = {
           this.g.localCurrencyRate = response.data.rate
           this.g.localCurrency = currency
           this.$q.localStorage.set('lnbits.localCurrency', this.g.localCurrency)
+          EventHub.$emit("update-local-currency", {currency: currency, rate: response.data.rate})
         })
       }
     },

--- a/lnbits/static/js/base.js
+++ b/lnbits/static/js/base.js
@@ -395,13 +395,15 @@ window.windowMixin = {
         LNbits.utils.notifyApiError(err)
       })
 
-    currency = this.$q.localStorage.getItem('lnbits.localCurrency')
-    if (currency) {
-      this.setLocalCurrency(currency)
+    if (window.showFiat) {
+      currency = this.$q.localStorage.getItem('lnbits.localCurrency')
+      if (currency) {
+        this.setLocalCurrency(currency)
+      }
+      setInterval(() => {
+        this.setLocalCurrency(this.g.localCurrency)
+      }, 600000)
     }
-    setInterval(() => {
-      this.setLocalCurrency(this.g.localCurrency)
-    }, 600000)
 
     if (window.extensions) {
       var user = this.g.user

--- a/lnbits/static/js/components.js
+++ b/lnbits/static/js/components.js
@@ -22,7 +22,9 @@ Vue.component('lnbits-wallet-list', {
       activeWallet: null,
       activeBalance: [],
       showForm: false,
-      walletName: ''
+      walletName: '',
+      localCurrencyRate: 1,
+      localCurrency: "sat",
     }
   },
   template: `
@@ -43,7 +45,8 @@ Vue.component('lnbits-wallet-list', {
         </q-item-section>
         <q-item-section>
           <q-item-label lines="1">{{ wallet.name }}</q-item-label>
-          <q-item-label caption>{{ wallet.live_fsat }} sat</q-item-label>
+          <q-item-label v-if="localCurrency=='sat'" caption>{{ wallet.live_fsat }} sat</q-item-label>
+          <q-item-label v-else caption>{{ formattedValueLocal(wallet.sat) }}</q-item-label>
         </q-item-section>
         <q-item-section side v-show="activeWallet && activeWallet.id === wallet.id">
           <q-icon name="chevron_right" color="grey-5" size="md"></q-icon>
@@ -88,6 +91,13 @@ Vue.component('lnbits-wallet-list', {
     },
     updateWalletBalance: function (payload) {
       this.activeBalance = payload
+    },
+    setLocalCurrency: function({currency, rate}) {
+      this.localCurrency = currency
+      this.localCurrencyRate = rate
+    },
+    formattedValueLocal: function (from_sats) {
+      return LNbits.utils.formatCurrency(from_sats * this.localCurrencyRate, this.localCurrency)
     }
   },
   created: function () {
@@ -98,6 +108,7 @@ Vue.component('lnbits-wallet-list', {
       this.activeWallet = LNbits.map.wallet(window.wallet)
     }
     EventHub.$on('update-wallet-balance', this.updateWalletBalance)
+    EventHub.$on('update-local-currency', this.setLocalCurrency)
   }
 })
 

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -49,6 +49,17 @@
             >
           </q-badge>
           {% endblock %}
+          <q-select
+            filled
+            dense
+            dark
+            v-model="g.localCurrency"
+            v-if="g.user"
+            type="text"
+            :options="g.localCurrencies"
+            @input="setLocalCurrency"
+          ></q-select>
+
           <q-btn-dropdown
             v-if="g.allowedThemes && g.allowedThemes.length > 1"
             dense

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -49,6 +49,7 @@
             >
           </q-badge>
           {% endblock %}
+          {% if LNBITS_SHOW_FIAT %}
           <q-select
             filled
             dense
@@ -59,6 +60,7 @@
             :options="g.localCurrencies"
             @input="setLocalCurrency"
           ></q-select>
+          {% endif %}
 
           <q-btn-dropdown
             v-if="g.allowedThemes && g.allowedThemes.length > 1"
@@ -206,6 +208,7 @@
       if(themes && themes.length) {
         window.allowedThemes = themes.map(str => str.trim())
       }
+      window.showFiat = {{ LNBITS_SHOW_FIAT | tojson }}
     </script>
     {% block scripts %}{% endblock %}
   </body>

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -264,3 +264,25 @@ async def get_fiat_rate_satoshis(currency: str) -> float:
 
 async def fiat_amount_as_satoshis(amount: float, currency: str) -> int:
     return int(amount * (await get_fiat_rate_satoshis(currency)))
+
+
+async def get_fiat_btc_rate_satoshis(currency: str) -> float:
+    btc_sat_rates = {
+            "sat": 1,
+            "msat": 0.001,
+            "btc": 100000000,
+    }
+
+    if currency in btc_sat_rates:
+        return btc_sat_rates[currency]
+    else:
+        return await get_fiat_rate_satoshis(currency)
+
+
+async def get_rate(currency_from: str, currency_to: str) -> float:
+    rate_from = \
+        await get_fiat_btc_rate_satoshis(currency_from)
+    rate_to = \
+        await get_fiat_btc_rate_satoshis(currency_to)
+
+    return rate_from / rate_to


### PR DESCRIPTION
This adds a local fiat currency selection dropdown to the top left corner. When any currency other than sats is selected, the balance will be displayed in the local currency below the sats balance. The transaction table also gets a new column containing the converted values for each TX.

Currently the wallet list on the left does not get a conversion since I am not sure yet how this should look.

Summary of current status:

* New API path added: 'api/v1/rates' to get the exchange rate for various currencies
    * This currently requires a valid admin key, in order to prevent non-account holders from spamming the API
    *  Makes use of functions in exchange_rates.py
* base.js contains additional methods to handle local currency selection and calling the new rates API
    * Local currency selection stored in local storage
* base.html has the drop-down added
* wallet.js has a new method formattedValueLocal, which converts a sats value to a local currency, based on rate and local currency
* When creating a new invoice, the selected local currency is automatically selected as default
* When paying an invoice, the invoice value is also displayed in the local currency

Possible improvements needed:
* ✔️ Regular update of rate based on some kind of timer to keep exchange rate up to date when not refreshing the page
* Conversion of wallet balances on left hand menu
* Some extensions could also make use of this. The tpos can make use of the new API path to get exchange rates.
* Some tidy up of the code
* ✔️  only show when a .env variable is enabled
* Add API docs