### PR TITLE
Return a valid getinfo JSON response in the lndhub extension

### DIFF
--- a/lnbits/extensions/lndhub/views_api.py
+++ b/lnbits/extensions/lndhub/views_api.py
@@ -15,7 +15,7 @@ from .utils import to_buffer, decoded_as_lndhub
 
 @lndhub_ext.route("/ext/getinfo", methods=["GET"])
 async def lndhub_getinfo():
-    return jsonify({"error": True, "code": 1, "message": "bad auth"})
+    return jsonify({"alias": "lnbits-lndhub"})
 
 
 @lndhub_ext.route("/ext/auth", methods=["POST"])


### PR DESCRIPTION
The lndhub extension currently returns a "bad auth" error on the /getinfo call.

Ideally we respond with the exact same JSON as LndHub, but we might not have all that information. 
Still we should at least return a valid response here.