### PR TITLE
Fix DB Lock: open database only when reading and writing to it

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -142,24 +142,26 @@ async def pay_invoice(
         if wallet.balance_msat < 0:
             raise PermissionError("Insufficient balance.")
 
-        if internal_checking_id:
-            # mark the invoice from the other side as not pending anymore
-            # so the other side only has access to his new money when we are sure
-            # the payer has enough to deduct from
+    if internal_checking_id:
+        # mark the invoice from the other side as not pending anymore
+        # so the other side only has access to his new money when we are sure
+        # the payer has enough to deduct from
+        async with db.connect() as conn:
             await update_payment_status(
                 checking_id=internal_checking_id,
                 pending=False,
                 conn=conn,
             )
 
-            # notify receiver asynchronously
-            from lnbits.tasks import internal_invoice_paid
+        # notify receiver asynchronously
+        from lnbits.tasks import internal_invoice_paid
 
-            await internal_invoice_paid.send(internal_checking_id)
-        else:
-            # actually pay the external invoice
-            payment: PaymentResponse = await WALLET.pay_invoice(payment_request)
-            if payment.checking_id:
+        await internal_invoice_paid.send(internal_checking_id)
+    else:
+        # actually pay the external invoice
+        payment: PaymentResponse = await WALLET.pay_invoice(payment_request)
+        if payment.checking_id:
+            async with db.connect() as conn:
                 await create_payment(
                     checking_id=payment.checking_id,
                     fee=payment.fee_msat,
@@ -169,13 +171,13 @@ async def pay_invoice(
                     **payment_kwargs,
                 )
                 await delete_payment(temp_id, conn=conn)
-            else:
-                raise PaymentFailure(
-                    payment.error_message
-                    or "Payment failed, but backend didn't give us an error message."
-                )
+        else:
+            raise PaymentFailure(
+                payment.error_message
+                or "Payment failed, but backend didn't give us an error message."
+            )
 
-        return invoice.payment_hash
+    return invoice.payment_hash
 
 
 async def redeem_lnurl_withdraw(
@@ -324,7 +326,8 @@ async def check_invoice_status(
     if not payment.pending:
         return status
     if payment.is_out and status.failed:
-        print(f" - deleting outgoing failed payment {payment.checking_id}: {status}")
+        print(
+            f" - deleting outgoing failed payment {payment.checking_id}: {status}")
         await payment.delete()
     elif not status.pending:
         print(


### PR DESCRIPTION
This one is critical but possibly not the most elegant way to fix it. 

Problem: 
* The entire `pay_invoice` routine was in the database with block (`async with (db.reuse_conn(conn) if conn else db.connect()) as conn`). However, the database access isn't concurrent. When the payment takes a long time, this can lead to the entire instance getting stuck until the payment is resolved. If the payment takes longer than the timeout of the wallet interface, this can lead to "big problems".

Fix: 
* Open (and lock) the database only immediately before it is written to, avoiding a locked state while the payment is being attempted.  

Comments:
* I could not use `db.reuse_conn(conn)` because the connection closes after the `with` block. Now, it `.conenct()`'s every time the db is accessed again. Possibly, someone would like to have this differently (I'm too new to judge)
* Line 162: `payment: PaymentResponse = await WALLET.pay_invoice(payment_request)` can take a very long time to complete, depending on the payment. This is ok, as long as the thread waits for it. The current code blocks the entire instance of lnbits when it gets stuck here. This is because of the database, which aquires a lock and doesn't support concurrency (at least the SQLIte db, no idea about Postgres).
* Inside `WALLET.pay_invoice` for each wallet, I recommend setting a very long timeout. Right now, for LNDRestWallet and LNPaywallet (and possibly others), the time is set to 180s. I recommend something absurdly long, such as 24h or even 2 weeks (fiatjaf).
* For the future: RPC-LND has a `timeout_seconds` flag ([link](https://api.lightning.community/#sendpaymentv2)) that can limit the time lnd will try to find a route (note: if a route is already being tried, this won't change much). It might make sense to include this in the RPC call.  
* With REST, the endpoint `/v1/channels/transactions` does not support this flag 🤦 – for that, we would have to probe the route ourselves and use the [route-send](https://api.lightning.community/#v2-router-route-send) endpoint.