### PR TITLE
LNDRest fee limit

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -173,6 +173,8 @@ async def pay_invoice(
                 await delete_payment(temp_id, conn=conn)
         else:
             print("---- ERROR CAUGHT ----")
+            async with db.connect() as conn:
+                await delete_payment(temp_id, conn=conn)
             raise PaymentFailure(
                 payment.error_message
                 or "Payment failed, but backend didn't give us an error message."

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -172,9 +172,8 @@ async def pay_invoice(
                 )
                 await delete_payment(temp_id, conn=conn)
         else:
-            print("---- ERROR CAUGHT ----")
-            # async with db.connect() as conn:
-            #    await delete_payment(temp_id, conn=conn)
+            async with db.connect() as conn:
+                await delete_payment(temp_id, conn=conn)
             raise PaymentFailure(
                 payment.error_message
                 or "Payment failed, but backend didn't give us an error message."

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -172,6 +172,7 @@ async def pay_invoice(
                 )
                 await delete_payment(temp_id, conn=conn)
         else:
+            print("---- ERROR CAUGHT ----")
             raise PaymentFailure(
                 payment.error_message
                 or "Payment failed, but backend didn't give us an error message."

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -173,8 +173,8 @@ async def pay_invoice(
                 await delete_payment(temp_id, conn=conn)
         else:
             print("---- ERROR CAUGHT ----")
-            async with db.connect() as conn:
-                await delete_payment(temp_id, conn=conn)
+            # async with db.connect() as conn:
+            #    await delete_payment(temp_id, conn=conn)
             raise PaymentFailure(
                 payment.error_message
                 or "Payment failed, but backend didn't give us an error message."

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -70,7 +70,7 @@ async def api_payments():
             )
         )
 
-    pendingPayments = await get_payments(wallet_id=g.wallet.id, pending=True)
+    pendingPayments = await get_payments(wallet_id=g.wallet.id, pending=True, exclude_uncheckable=True)
     for payment in pendingPayments:
         await check_invoice_status(
             wallet_id=payment.wallet_id, payment_hash=payment.payment_hash

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -115,7 +115,6 @@ class LndRestWallet(Wallet):
                 },
                 timeout=180,
             )
-            print(r.json())
 
         if r.is_error or r.json().get("payment_error"):
             error_message = r.json().get("payment_error") or r.text

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -98,15 +98,13 @@ class LndRestWallet(Wallet):
 
     async def pay_invoice(self, bolt11: str) -> PaymentResponse:
         async with httpx.AsyncClient(verify=self.cert) as client:
-
             # set the fee limit for the payment
             invoice = lnbits_bolt11.decode(bolt11)
             lnrpcFeeLimit = dict()
-            # if invoice.amount_msat > 1000_000:
-            #     lnrpcFeeLimit["percent"] = "1"  # in percent
-            # else:
-            #     lnrpcFeeLimit["fixed"] = "10"  # in sat
-            lnrpcFeeLimit["fixed"] = "1"
+            if invoice.amount_msat > 1000_000:
+                lnrpcFeeLimit["percent"] = "1"  # in percent
+            else:
+                lnrpcFeeLimit["fixed"] = "10"  # in sat
 
             r = await client.post(
                 url=f"{self.endpoint}/v1/channels/transactions",
@@ -121,7 +119,6 @@ class LndRestWallet(Wallet):
 
         if r.is_error or r.json().get("payment_error"):
             error_message = r.json().get("payment_error") or r.text
-            print(f"We have an ordinary error: {error_message}")
             return PaymentResponse(False, None, 0, None, error_message)
 
         data = r.json()

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -96,10 +96,17 @@ class LndRestWallet(Wallet):
 
     async def pay_invoice(self, bolt11: str) -> PaymentResponse:
         async with httpx.AsyncClient(verify=self.cert) as client:
+            invoice = bolt11.decode(bolt11)
             r = await client.post(
                 url=f"{self.endpoint}/v1/channels/transactions",
                 headers=self.auth,
-                json={"payment_request": bolt11},
+                json={
+                    "payment_request": bolt11,
+                    "fee_limit": {
+                        "percent": "1" if invoice.amount_msat >= 1000_000 else "0",
+                        "fixed": "0" if invoice.amount_msat < 1000_000 else "10"
+                    }
+                },
                 timeout=180,
             )
 

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -121,6 +121,7 @@ class LndRestWallet(Wallet):
 
         if r.is_error or r.json().get("payment_error"):
             error_message = r.json().get("payment_error") or r.text
+            print(f"We have an ordinary error: {error_message}")
             return PaymentResponse(False, None, 0, None, error_message)
 
         data = r.json()

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -5,6 +5,8 @@ import base64
 from os import getenv
 from typing import Optional, Dict, AsyncGenerator
 
+from lnbits import bolt11 as lnbits_bolt11
+
 from .base import (
     StatusResponse,
     InvoiceResponse,
@@ -96,7 +98,7 @@ class LndRestWallet(Wallet):
 
     async def pay_invoice(self, bolt11: str) -> PaymentResponse:
         async with httpx.AsyncClient(verify=self.cert) as client:
-            invoice = bolt11.decode(bolt11)
+            invoice = lnbits_bolt11.decode(bolt11)
             r = await client.post(
                 url=f"{self.endpoint}/v1/channels/transactions",
                 headers=self.auth,

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -105,8 +105,8 @@ class LndRestWallet(Wallet):
                 json={
                     "payment_request": bolt11,
                     "fee_limit": {
-                        "percent": "1" if invoice.amount_msat >= 1000_000 else "0",
-                        "fixed": "0" if invoice.amount_msat < 1000_000 else "10"
+                        "percent": "1" if invoice.amount_msat > 1000_000 else "0",
+                        "fixed": "0" if invoice.amount_msat <= 1000_000 else "10"
                     }
                 },
                 timeout=180,

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -105,8 +105,8 @@ class LndRestWallet(Wallet):
                 json={
                     "payment_request": bolt11,
                     "fee_limit": {
-                        "percent": "1"  # if invoice.amount_msat > 1000_000 else "0",
-                        # "fixed": "0" if invoice.amount_msat <= 1000_000 else "10"
+                        # "percent": "1"  # if invoice.amount_msat > 1000_000 else "0",
+                        "fixed": "10"  # if invoice.amount_msat <= 1000_000 else "10"
                     }
                 },
                 timeout=180,

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -106,7 +106,7 @@ class LndRestWallet(Wallet):
                     "payment_request": bolt11,
                     "fee_limit": {
                         # "percent": "1"  # if invoice.amount_msat > 1000_000 else "0",
-                        "fixed": "10"  # if invoice.amount_msat <= 1000_000 else "10"
+                        "fixed": "1"  # if invoice.amount_msat <= 1000_000 else "10"
                     }
                 },
                 timeout=180,

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -102,10 +102,11 @@ class LndRestWallet(Wallet):
             # set the fee limit for the payment
             invoice = lnbits_bolt11.decode(bolt11)
             lnrpcFeeLimit = dict()
-            if invoice.amount_msat > 1000_000:
-                lnrpcFeeLimit["percent"] = "1"  # in percent
-            else:
-                lnrpcFeeLimit["fixed"] = "10"  # in sat
+            # if invoice.amount_msat > 1000_000:
+            #     lnrpcFeeLimit["percent"] = "1"  # in percent
+            # else:
+            #     lnrpcFeeLimit["fixed"] = "10"  # in sat
+            lnrpcFeeLimit["fixed"] = "1"
 
             r = await client.post(
                 url=f"{self.endpoint}/v1/channels/transactions",

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -105,8 +105,8 @@ class LndRestWallet(Wallet):
                 json={
                     "payment_request": bolt11,
                     "fee_limit": {
-                        "percent": "1" if invoice.amount_msat > 1000_000 else "0",
-                        "fixed": "0" if invoice.amount_msat <= 1000_000 else "10"
+                        "percent": "1"  # if invoice.amount_msat > 1000_000 else "0",
+                        # "fixed": "0" if invoice.amount_msat <= 1000_000 else "10"
                     }
                 },
                 timeout=180,


### PR DESCRIPTION
Adds `fee_limit` to the the payment.

Policy: 
```python
if invoice.amount_msat > 1000_000:
    lnrpcFeeLimit["percent"] = "1"  # in percent
else:
    lnrpcFeeLimit["fixed"] = "10"  # in sat
```

What changed?
1) Add `fee_limit`. 
2) When payment fails, delete temporary DB entry. Why didn't we do this before? 
3) `check_invoice_status` in `api.py` (`/api/v1/payments`) now `exclude_uncheckable=True`. This excludes DB entries with the `temp_` prefix, that can't be checked (and probably should not be checked?).

