### PR TITLE
United fee limit

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -159,7 +159,7 @@ async def pay_invoice(
         await internal_invoice_paid.send(internal_checking_id)
     else:
         # actually pay the external invoice
-        payment: PaymentResponse = await WALLET.pay_invoice(payment_request)
+        payment: PaymentResponse = await WALLET.pay_invoice(payment_request, fee_reserve(invoice.amount_msat))
         if payment.checking_id:
             async with db.connect() as conn:
                 await create_payment(

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -343,4 +343,4 @@ async def check_invoice_status(
 
 # WARN: this same value must be used for balance check and passed to WALLET.pay_invoice(), it may cause a vulnerability if the values differ
 def fee_reserve(amount_msat: int) -> int:
-    return max(1000, int(amount_msat * 0.01))
+    return max(2000, int(amount_msat * 0.01))

--- a/lnbits/wallets/base.py
+++ b/lnbits/wallets/base.py
@@ -59,6 +59,8 @@ class Wallet(ABC):
     ) -> Coroutine[None, None, InvoiceResponse]:
         pass
 
+    # WARNING: correct handling of fee_limit_msat is required to avoid security vulnerabilities!
+    # The backend MUST NOT spend satoshis above invoice amount + fee_limit_msat.
     @abstractmethod
     def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> Coroutine[None, None, PaymentResponse]:
         pass

--- a/lnbits/wallets/base.py
+++ b/lnbits/wallets/base.py
@@ -60,7 +60,7 @@ class Wallet(ABC):
         pass
 
     @abstractmethod
-    def pay_invoice(self, bolt11: str) -> Coroutine[None, None, PaymentResponse]:
+    def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> Coroutine[None, None, PaymentResponse]:
         pass
 
     @abstractmethod

--- a/lnbits/wallets/clightning.py
+++ b/lnbits/wallets/clightning.py
@@ -88,7 +88,8 @@ class CLightningWallet(Wallet):
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         invoice = lnbits_bolt11.decode(bolt11)
-        fee_limit_percent = (invoice.amount_msat // fee_limit_msat) // 100
+       fee_limit_percent = fee_limit_msat / invoice.amount_msat * 100
+
 
         payload = {
             "bolt11" : bolt11,

--- a/lnbits/wallets/clightning.py
+++ b/lnbits/wallets/clightning.py
@@ -84,7 +84,7 @@ class CLightningWallet(Wallet):
             error_message = f"lightningd '{exc.method}' failed with '{exc.error}'."
             return InvoiceResponse(False, label, None, error_message)
 
-    async def pay_invoice(self, bolt11: str) -> PaymentResponse:
+    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         try:
             r = self.ln.pay(bolt11)
         except RpcError as exc:

--- a/lnbits/wallets/clightning.py
+++ b/lnbits/wallets/clightning.py
@@ -92,7 +92,7 @@ class CLightningWallet(Wallet):
 
         payload = {
             "bolt11" : bolt11,
-            "maxfeepercent" : fee_limit_percent
+            "maxfeepercent" : "{:.1f}".format(fee_limit_percent)
         }
         
         try:

--- a/lnbits/wallets/clightning.py
+++ b/lnbits/wallets/clightning.py
@@ -86,6 +86,8 @@ class CLightningWallet(Wallet):
             error_message = f"lightningd '{exc.method}' failed with '{exc.error}'."
             return InvoiceResponse(False, label, None, error_message)
 
+    # WARNING: correct handling of fee_limit_msat is required to avoid security vulnerabilities!
+    # The backend MUST NOT spend satoshis above invoice amount + fee_limit_msat.
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         invoice = lnbits_bolt11.decode(bolt11)
         fee_limit_percent = fee_limit_msat / invoice.amount_msat * 100

--- a/lnbits/wallets/clightning.py
+++ b/lnbits/wallets/clightning.py
@@ -88,8 +88,7 @@ class CLightningWallet(Wallet):
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         invoice = lnbits_bolt11.decode(bolt11)
-       fee_limit_percent = fee_limit_msat / invoice.amount_msat * 100
-
+        fee_limit_percent = fee_limit_msat / invoice.amount_msat * 100
 
         payload = {
             "bolt11" : bolt11,

--- a/lnbits/wallets/clightning.py
+++ b/lnbits/wallets/clightning.py
@@ -94,7 +94,7 @@ class CLightningWallet(Wallet):
 
         payload = {
             "bolt11" : bolt11,
-            "maxfeepercent" : fee_limit_percent,
+            "maxfeepercent" : "{:.11}".format(fee_limit_percent),
             "exemptfee": 0 # so fee_limit_percent is applied even on payments with fee under 5000 millisatoshi (which is default value of exemptfee)
         }
         

--- a/lnbits/wallets/clightning.py
+++ b/lnbits/wallets/clightning.py
@@ -94,7 +94,8 @@ class CLightningWallet(Wallet):
 
         payload = {
             "bolt11" : bolt11,
-            "maxfeepercent" : "{:.1f}".format(fee_limit_percent)
+            "maxfeepercent" : fee_limit_percent,
+            "exemptfee": 0 # so fee_limit_percent is applied even on payments with fee under 5000 millisatoshi (which is default value of exemptfee)
         }
         
         try:

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -84,6 +84,8 @@ class LNbitsWallet(Wallet):
 
         return InvoiceResponse(ok, checking_id, payment_request, error_message)
 
+    # WARNING: correct handling of fee_limit_msat is required to avoid security vulnerabilities!
+    # The backend MUST NOT spend satoshis above invoice amount + fee_limit_msat.
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient() as client:
             r = await client.post(

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -84,7 +84,7 @@ class LNbitsWallet(Wallet):
 
         return InvoiceResponse(ok, checking_id, payment_request, error_message)
 
-    async def pay_invoice(self, bolt11: str) -> PaymentResponse:
+    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient() as client:
             r = await client.post(
                 url=f"{self.endpoint}/api/v1/payments",

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -144,6 +144,8 @@ class LndWallet(Wallet):
         payment_request = str(resp.payment_request)
         return InvoiceResponse(True, checking_id, payment_request, None)
 
+    # WARNING: correct handling of fee_limit_msat is required to avoid security vulnerabilities!
+    # The backend MUST NOT spend satoshis above invoice amount + fee_limit_msat.
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         fee_limit_fixed = ln.FeeLimit(fixed=fee_limit_msat//1000)
         req = ln.SendRequest(payment_request=bolt11, fee_limit=fee_limit_fixed)

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -144,7 +144,7 @@ class LndWallet(Wallet):
         payment_request = str(resp.payment_request)
         return InvoiceResponse(True, checking_id, payment_request, None)
 
-    async def pay_invoice(self, bolt11: str) -> PaymentResponse:
+    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         resp = self.rpc.send_payment(payment_request=bolt11)
 
         if resp.payment_error:

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -145,7 +145,9 @@ class LndWallet(Wallet):
         return InvoiceResponse(True, checking_id, payment_request, None)
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
-        resp = self.rpc.send_payment(payment_request=bolt11)
+        fee_limit_fixed = ln.FeeLimit(fixed=fee_limit_msat//1000)
+        req = ln.SendRequest(payment_request=bolt11, fee_limit=fee_limit_fixed)
+        resp = self.rpc._ln_stub.SendPaymentSync(req)
 
         if resp.payment_error:
             return PaymentResponse(False, "", 0, None, resp.payment_error)

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -94,6 +94,8 @@ class LndRestWallet(Wallet):
 
         return InvoiceResponse(True, checking_id, payment_request, None)
 
+    # WARNING: correct handling of fee_limit_msat is required to avoid security vulnerabilities!
+    # The backend MUST NOT spend satoshis above invoice amount + fee_limit_msat.
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient(verify=self.cert) as client:
             # set the fee limit for the payment

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -96,15 +96,12 @@ class LndRestWallet(Wallet):
 
         return InvoiceResponse(True, checking_id, payment_request, None)
 
-    async def pay_invoice(self, bolt11: str) -> PaymentResponse:
+    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient(verify=self.cert) as client:
             # set the fee limit for the payment
             invoice = lnbits_bolt11.decode(bolt11)
             lnrpcFeeLimit = dict()
-            if invoice.amount_msat > 1000_000:
-                lnrpcFeeLimit["percent"] = "1"  # in percent
-            else:
-                lnrpcFeeLimit["fixed"] = "10"  # in sat
+            lnrpcFeeLimit["fixed"] = "{}".format(fee_limit_msat//1000)  # in sat
 
             r = await client.post(
                 url=f"{self.endpoint}/v1/channels/transactions",

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -5,8 +5,6 @@ import base64
 from os import getenv
 from typing import Optional, Dict, AsyncGenerator
 
-from lnbits import bolt11 as lnbits_bolt11
-
 from .base import (
     StatusResponse,
     InvoiceResponse,
@@ -99,9 +97,8 @@ class LndRestWallet(Wallet):
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient(verify=self.cert) as client:
             # set the fee limit for the payment
-            invoice = lnbits_bolt11.decode(bolt11)
             lnrpcFeeLimit = dict()
-            lnrpcFeeLimit["fixed"] = "{}".format(fee_limit_msat//1000)  # in sat
+            lnrpcFeeLimit["fixed_msat"] = "{}".format(fee_limit_msat)
 
             r = await client.post(
                 url=f"{self.endpoint}/v1/channels/transactions",

--- a/lnbits/wallets/lnpay.py
+++ b/lnbits/wallets/lnpay.py
@@ -76,7 +76,7 @@ class LNPayWallet(Wallet):
 
         return InvoiceResponse(ok, checking_id, payment_request, error_message)
 
-    async def pay_invoice(self, bolt11: str) -> PaymentResponse:
+    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient() as client:
             r = await client.post(
                 f"{self.endpoint}/wallet/{self.wallet_key}/withdraw",

--- a/lnbits/wallets/lnpay.py
+++ b/lnbits/wallets/lnpay.py
@@ -76,6 +76,8 @@ class LNPayWallet(Wallet):
 
         return InvoiceResponse(ok, checking_id, payment_request, error_message)
 
+    # WARNING: correct handling of fee_limit_msat is required to avoid security vulnerabilities!
+    # The backend MUST NOT spend satoshis above invoice amount + fee_limit_msat.
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient() as client:
             r = await client.post(

--- a/lnbits/wallets/lntxbot.py
+++ b/lnbits/wallets/lntxbot.py
@@ -79,7 +79,7 @@ class LntxbotWallet(Wallet):
         data = r.json()
         return InvoiceResponse(True, data["payment_hash"], data["pay_req"], None)
 
-    async def pay_invoice(self, bolt11: str) -> PaymentResponse:
+    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient() as client:
             r = await client.post(
                 f"{self.endpoint}/payinvoice",

--- a/lnbits/wallets/lntxbot.py
+++ b/lnbits/wallets/lntxbot.py
@@ -79,6 +79,8 @@ class LntxbotWallet(Wallet):
         data = r.json()
         return InvoiceResponse(True, data["payment_hash"], data["pay_req"], None)
 
+    # WARNING: correct handling of fee_limit_msat is required to avoid security vulnerabilities!
+    # The backend MUST NOT spend satoshis above invoice amount + fee_limit_msat.
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient() as client:
             r = await client.post(

--- a/lnbits/wallets/opennode.py
+++ b/lnbits/wallets/opennode.py
@@ -77,7 +77,7 @@ class OpenNodeWallet(Wallet):
         payment_request = data["lightning_invoice"]["payreq"]
         return InvoiceResponse(True, checking_id, payment_request, None)
 
-    async def pay_invoice(self, bolt11: str) -> PaymentResponse:
+    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient() as client:
             r = await client.post(
                 f"{self.endpoint}/v2/withdrawals",

--- a/lnbits/wallets/opennode.py
+++ b/lnbits/wallets/opennode.py
@@ -77,6 +77,8 @@ class OpenNodeWallet(Wallet):
         payment_request = data["lightning_invoice"]["payreq"]
         return InvoiceResponse(True, checking_id, payment_request, None)
 
+    # WARNING: correct handling of fee_limit_msat is required to avoid security vulnerabilities!
+    # The backend MUST NOT spend satoshis above invoice amount + fee_limit_msat.
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         async with httpx.AsyncClient() as client:
             r = await client.post(

--- a/lnbits/wallets/spark.py
+++ b/lnbits/wallets/spark.py
@@ -108,6 +108,8 @@ class SparkWallet(Wallet):
 
         return InvoiceResponse(ok, checking_id, payment_request, error_message)
 
+    # WARNING: correct handling of fee_limit_msat is required to avoid security vulnerabilities!
+    # The backend MUST NOT spend satoshis above invoice amount + fee_limit_msat.
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         try:
             r = await self.pay(bolt11)

--- a/lnbits/wallets/spark.py
+++ b/lnbits/wallets/spark.py
@@ -108,7 +108,7 @@ class SparkWallet(Wallet):
 
         return InvoiceResponse(ok, checking_id, payment_request, error_message)
 
-    async def pay_invoice(self, bolt11: str) -> PaymentResponse:
+    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         try:
             r = await self.pay(bolt11)
         except (SparkError, UnknownError) as exc:

--- a/lnbits/wallets/void.py
+++ b/lnbits/wallets/void.py
@@ -23,7 +23,7 @@ class VoidWallet(Wallet):
         print("This backend does nothing, it is here just as a placeholder, you must configure an actual backend before being able to do anything useful with LNbits.")
         return StatusResponse(None, 0)
 
-    async def pay_invoice(self, bolt11: str) -> PaymentResponse:
+    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         raise Unsupported("")
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:


### PR DESCRIPTION
I was challenged by callebyc so here is my very first PR ever.

- The fee limit is now determined from `fee_reserve()` and passed to WALLET.pay_invoice(), to ensure maintaining fee limit = fee reserve (otherwise it may cause a vulnerability).

- This fee limit is now implemented in `LndRestWallet`, `LndWallet` and `CLightningWallet` (here the 0.5% default fee limit is being overwritten).


Thanks for your feedback and to Kixunil for his guidance.

