### PR TITLE
New extension: Autopay - scheduled LNURL payments

### DIFF
--- a/lnbits/extensions/autopay/__init__.py
+++ b/lnbits/extensions/autopay/__init__.py
@@ -1,0 +1,30 @@
+from quart import Blueprint
+from lnbits.db import Database
+
+from .context import AutopayContext
+
+
+db = Database("ext_autopay")
+
+autopay_ext: Blueprint = Blueprint(
+    "autopay", __name__, static_folder="static", template_folder="templates"
+)
+
+context = AutopayContext(db)
+
+
+import sys
+
+if "pytest" not in sys.modules:
+    # Only load these in prod, for some reason it fails under pytest
+    from .views_api import *  # noqa
+    from .views import *  # noqa
+
+    # Spawn a process that periodically hits the scheduler API
+    # TODO: use asyncio once lnbits updates to quart 0.16
+    # See https://stackoverflow.com/questions/70075859/scheduling-periodic-function-call-in-quart-asyncio
+    from lnbits.settings import HOST, PORT
+    import subprocess
+    scheduler_check_freq_secs = '60'
+    p = subprocess.Popen(['watch', '-n', scheduler_check_freq_secs, f"curl -k -X POST https://{HOST}:{PORT}/autopay/api/v1/scheduler"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    # p = subprocess.Popen(['watch', '-n', scheduler_check_freq_secs, f"curl -X POST http://{HOST}:{PORT}/autopay/api/v1/scheduler"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/lnbits/extensions/autopay/config.json
+++ b/lnbits/extensions/autopay/config.json
@@ -1,0 +1,6 @@
+{
+    "name": "AutoPay",
+    "short_description": "Schedule payments with LNBits",
+    "icon": "info",
+    "contributors": ["crowphale"]
+}

--- a/lnbits/extensions/autopay/context.py
+++ b/lnbits/extensions/autopay/context.py
@@ -1,0 +1,14 @@
+from .utils import lnurl_scan
+from .storage import SqliteStorage
+from .scheduler import Scheduler
+
+
+class AutopayContext(object):
+    """ Object that holds dependencies across requests, so that we can mock these out during tests. Sort of Dependency Injection container. """
+
+    def __init__(self, autopay_db):
+        self.lnurl_scan = lnurl_scan
+        self.storage = SqliteStorage(autopay_db)
+
+    def get_scheduler(self):
+        return Scheduler(self.storage)

--- a/lnbits/extensions/autopay/migrations.py
+++ b/lnbits/extensions/autopay/migrations.py
@@ -1,0 +1,26 @@
+async def m001_initial(db):
+   await db.execute(
+       f"""
+       CREATE TABLE autopay.schedule_entries (
+           id INTEGER PRIMARY KEY,
+           wallet_id TEXT NOT NULL,
+           title TEXT NOT NULL,
+           base_datetime TIMESTAMP NOT NULL,
+           repeat_freq TEXT NOT NULL,
+           lnurl TEXT NOT NULL,
+           amount_msat INTEGER NOT NULL,
+           created_at TIMESTAMP NOT NULL DEFAULT {db.timestamp_now},
+           is_deleted INTEGER NOT NULL DEFAULT 0
+       );
+   """
+   )
+   await db.execute(
+       f"""
+       CREATE TABLE autopay.payment_log (
+           id INTEGER PRIMARY KEY,
+           schedule_id INTEGER NOT NULL,
+           created_at TIMESTAMP NOT NULL DEFAULT {db.timestamp_now},
+           payment_hash TEXT
+       );
+   """
+   )

--- a/lnbits/extensions/autopay/models.py
+++ b/lnbits/extensions/autopay/models.py
@@ -1,0 +1,66 @@
+from typing import NamedTuple, Optional, Dict
+from sqlite3 import Row
+
+from datetime import datetime, timedelta
+
+
+BASE_DT_FORMAT = "%Y-%m-%d %H:%M"
+REPEAT_FREQ_OPTIONS = ["hour", "day", "week"]
+
+class ScheduleEntry(NamedTuple):
+    id: int
+    wallet_id: str
+    title: str
+    base_datetime: datetime
+    repeat_freq: str  # enum
+    lnurl: str
+    amount_msat: int
+
+    def next_run(self, already_executed_count=0):
+        # NOTE: doesn't handle daylight saving bullshits
+        if self.repeat_freq == "hour":
+            td = timedelta(hours=already_executed_count)
+        elif self.repeat_freq == "day":
+            td = timedelta(days=already_executed_count)
+        elif self.repeat_freq == "week":
+            td = timedelta(weeks=already_executed_count)
+        else:
+            raise ValueError(f"Unsupported repeat_freq: {self.repeat_freq}")
+
+        return self.base_datetime + td
+
+    @classmethod
+    def from_request(cls, data: dict, validator=None):
+
+        dt = datetime.strptime(data["base_datetime"], BASE_DT_FORMAT)
+
+        return cls(0, data["wallet_id"],
+            data["title"], dt, data["repeat_freq"], data["lnurl"], data["amount_msat"])
+
+    @classmethod
+    def validate_base_datetime(cls, base_dt: str, errors):
+        try:
+            dt = datetime.strptime(base_dt, BASE_DT_FORMAT)
+        except ValueError as e:
+            errors.append(f"'base_datetime' not in expected format: {e}")
+            return False
+
+        if dt <= datetime.now():
+            errors.append(f"'base_datetime' must be in the future.")
+            return False
+
+        return True
+
+    @classmethod
+    def validate_repeat_freq(cls, repeat_freq: str, errors):
+        if repeat_freq not in REPEAT_FREQ_OPTIONS:
+            errors.append(f"'repeat_freq' must be one of {REPEAT_FREQ_OPTIONS}, but got {repeat_freq}.")
+            return False
+        return True
+
+
+class PaymentLogEntry(NamedTuple):
+    id: int
+    schedule_id: int
+    created_at: int # timestamp
+    payment_hash: str

--- a/lnbits/extensions/autopay/scheduler.py
+++ b/lnbits/extensions/autopay/scheduler.py
@@ -1,0 +1,24 @@
+from .storage import Storage
+from .utils import execute_lnurl_payment
+from .models import PaymentLogEntry
+
+
+class Scheduler(object):
+    """ Takes care of scheduling payments. """
+
+    def __init__(self, storage: Storage, execute_payment=None):
+        self._storage = storage
+        self._execute_payment = execute_payment or execute_lnurl_payment
+
+    async def run(self, now):
+        """ This should be run periodically.
+        Go over all scheduled payments, and if should be run at `now`, execute payment. """
+        print("Autopay: Running scheduler")
+        for se in await self._storage.read_schedule_entries():
+            executed_count = await self._storage.read_payment_count(se.id)
+            next = se.next_run(executed_count)
+            print(f"Autopay: Checking schedule id={se.id} next={next} now={now}")
+            if next < now:
+                print(f"Autopay: Executing payment with wallet_id={se.wallet_id} {se.lnurl}")
+                hash = await self._execute_payment(se.wallet_id, se.lnurl, se.amount_msat)
+                await self._storage.create_payment_log(PaymentLogEntry(0, se.id, 0, hash))

--- a/lnbits/extensions/autopay/static/js/index.js
+++ b/lnbits/extensions/autopay/static/js/index.js
@@ -1,0 +1,131 @@
+var createEmptyScheduleEntry = function() {
+  return {
+    wallet: null,
+    amount_sat: 1,
+    base_datetime: "",
+    title: "",
+    lnurl: ""
+  };
+};
+
+var processScheduleEntry = function(entry) {
+  var processed = Object.assign({}, entry)
+
+  if (entry["wallet"]) {
+    processed["wallet_id"] = entry["wallet"]["value"];
+    delete processed["wallet"];
+  }
+
+  processed["amount_msat"] = entry["amount_sat"] * 1000;
+  delete processed["amount_sat"];
+
+  return processed;
+}
+
+new Vue({
+  el: '#vue',
+  mixins: [windowMixin],
+  data: function () {
+    return {
+      scheduleEntries: [],
+      newScheduleEntry: createEmptyScheduleEntry(),
+      scheduleFrequencyOptions: [
+        "hour", "day", "week", "month"
+      ]
+    }
+  },
+  methods: {
+    // Should be "computed" or "filter"?
+    walletName: function(id) {
+      return this.g.user.wallets.find(w => w.id === id).name;
+    },
+    formatAmount: function(msat) {
+      return `${msat / 1000}sats`;
+    },
+    walletOptions: function() {
+      return this.g.user.wallets.map(function(w) {
+        return {"value": w.id, "label": w.name};
+      });
+    },
+
+    submitNewScheduleEntry: function() {
+      var self = this;
+      var $q = this.$q;
+
+      var entry = processScheduleEntry(this.newScheduleEntry);
+
+      console.log("Creating...", entry);
+      axios({
+        method: 'POST',
+        url: '/autopay/api/v1/schedule',
+        data: entry
+      }).then(function (response) {
+
+        // Refresh the list
+        axios({
+          method: 'GET',
+          url: '/autopay/api/v1/schedule'
+        }).then(function (response) {
+          self.scheduleEntries = response.data.schedule;
+          self.newScheduleEntry = createEmptyScheduleEntry();
+
+          $q.notify({
+            timeout: 5000,
+            type: 'success',
+            message: `Payment scheduled`,
+            caption: null
+          });
+        });
+      }).catch(function(error) {
+        $q.notify({
+          timeout: 5000,
+          type: 'error',
+          message: `Failed to schedule payment`,
+          caption: error.response.data["message"]
+        });
+      })
+    },
+    deleteScheduleEntry: function(entry) {
+      var self = this;
+      var $q = this.$q;
+
+      axios({
+        method: 'DELETE',
+        url: '/autopay/api/v1/schedule/' + entry.id
+      }).then(function (response) {
+        // Refresh the list
+        axios({
+          method: 'GET',
+          url: '/autopay/api/v1/schedule'
+        }).then(function (response) {
+          self.scheduleEntries = response.data.schedule;
+          // self.newScheduleEntry = createEmptyScheduleEntry();
+
+          $q.notify({
+            timeout: 5000,
+            type: 'success',
+            message: `Schedule entry deleted`,
+            caption: null
+          });
+        });
+      }).catch(function(error) {
+        $q.notify({
+          timeout: 5000,
+          type: 'error',
+          message: `Failed to delete schedule`,
+          caption: error.response.data["message"]
+        });
+      });
+    }
+  },
+  created: function () {
+    var self = this
+
+    axios({
+      method: 'GET',
+      url: '/autopay/api/v1/schedule'
+    }).then(function (response) {
+      self.scheduleEntries = response.data.schedule;
+    });
+  }
+});

--- a/lnbits/extensions/autopay/storage.py
+++ b/lnbits/extensions/autopay/storage.py
@@ -1,0 +1,125 @@
+import asyncio
+from .models import *
+
+
+class Storage:
+    """ Manages persistent db storage (read/write). """
+
+    async def read_schedule_entries(self):
+        pass
+    async def create_schedule_entry(self, entry: ScheduleEntry):
+        pass
+    async def delete_schedule_entry(self, id: int):
+        pass
+
+    async def read_payment_count(self, schedule_id):
+        pass
+    async def read_payment_log_entries(self, schedule_id):
+        pass
+    async def create_payment_log(self, entry: PaymentLogEntry):
+        pass
+
+
+class InMemoryStorage(Storage):
+    def __init__(self):
+        self.schedule = []
+        self.payments = []
+        self._last_id = 0
+
+    @asyncio.coroutine
+    def read_schedule_entries(self):
+        return self.schedule
+
+    async def read_payment_count(self, schedule_id):
+        return len(await self.read_payment_log_entries(schedule_id))
+
+    @asyncio.coroutine
+    def read_payment_log_entries(self, schedule_id):
+        return [p for p in self.payments if p.schedule_id == schedule_id]
+
+    def _inc_id(self, entry: NamedTuple):
+        self._last_id += 1
+        return entry._replace(id=self._last_id)
+
+    @asyncio.coroutine
+    def create_schedule_entry(self, entry: ScheduleEntry):
+        self.schedule.append(self._inc_id(entry))
+
+    @asyncio.coroutine
+    def create_payment_log(self, entry: PaymentLogEntry):
+        self.payments.append(self._inc_id(entry))
+
+    @asyncio.coroutine
+    def delete_schedule_entry(self, id: int):
+        self.schedule = [s for s in self.schedule if s.id != id]
+
+
+def row_to_ScheduleEntry(row):
+    l = list(row[:-2])
+    l[3] = datetime.fromtimestamp(l[3])
+    return ScheduleEntry(*l)
+
+
+class SqliteStorage(Storage):
+    def __init__(self, db):
+        self._db = db
+
+    async def read_schedule_entries(self):
+        rows = await self._db.fetchall(
+            """
+            SELECT *
+            FROM autopay.schedule_entries
+            WHERE is_deleted = ?
+            """,
+            (0,),
+        )
+        return [row_to_ScheduleEntry(r) for r in rows]
+
+    async def create_schedule_entry(self, entry: ScheduleEntry):
+        await self._db.execute(
+            """
+            INSERT INTO autopay.schedule_entries (wallet_id, title, base_datetime, repeat_freq, lnurl, amount_msat)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (entry.wallet_id, entry.title, datetime.timestamp(entry.base_datetime), entry.repeat_freq, entry.lnurl, entry.amount_msat)
+        )
+
+    async def delete_schedule_entry(self, id: int):
+        await self._db.execute(
+            """
+            UPDATE autopay.schedule_entries
+            SET is_deleted = 1
+            WHERE id = ?
+            """,
+            (id,)
+        )
+
+    async def read_payment_count(self, schedule_id):
+        row = await self._db.fetchone(
+            """
+            SELECT COUNT(*)
+            FROM autopay.payment_log
+            WHERE schedule_id = ?
+            """,
+            (schedule_id,)
+        )
+        return row[0]
+
+    async def read_payment_log_entries(self, schedule_id):
+        rows = await self._db.fetchall(
+            """
+            SELECT *
+            FROM autopay.payment_log
+            WHERE schedule_id = ?
+            """,
+            (schedule_id,))
+        return [PaymentLogEntry(*r) for r in rows]
+
+    async def create_payment_log(self, entry: PaymentLogEntry):
+        await self._db.execute(
+            """
+            INSERT INTO autopay.payment_log (schedule_id, payment_hash)
+            VALUES (?, ?)
+            """,
+            (entry.schedule_id, entry.payment_hash)
+        )

--- a/lnbits/extensions/autopay/templates/autopay/index.html
+++ b/lnbits/extensions/autopay/templates/autopay/index.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %} {% from "macros.jinja" import window_vars with context
+%}
+
+{% block scripts %} {{ window_vars(user) }}
+<script src="/autopay/static/js/index.js"></script>
+{% endblock %}
+
+{% block page %}
+<q-card>
+  <q-card-section>
+    <h5 class="text-subtitle1 q-mt-none q-mb-md">
+      Scheduled payments
+    </h5>
+    <q-list>
+      <q-item
+        v-for="se in scheduleEntries"
+        v-bind:key="se.id"
+      >
+        {% raw %}
+        <q-item-section>
+          <q-item-label>{{ se.title }} ({{ formatAmount(se.amount_msat) }} from {{ walletName(se.wallet_id) }})
+            <q-btn flat dense
+              @click="deleteScheduleEntry(se)"
+              icon="delete"
+              title="Delete"
+              ></q-btn>
+            </q-item-label>
+          <q-item-label caption>{{se.base_datetime}} and then every {{se.repeat_freq}} </q-item-label>
+          <q-item-label caption>
+            Next payment: {{se.next_payment}}
+          </q-item-label>
+        </q-item-section>
+        {% endraw %}
+      </q-item>
+    </q-list>
+
+
+    <q-separator class="q-my-lg"></q-separator>
+    <h5 class="text-subtitle1 q-mt-none q-mb-md">
+      Schedule new payment
+    </h5>
+
+    <q-form @submit="submitNewScheduleEntry" class="q-gutter-md">
+{% raw %}
+      <q-input
+        filled
+        dense
+        v-model.trim="newScheduleEntry.title"
+        label="Title"
+        placeholder=""
+      ></q-input>
+
+      <q-select
+        filled
+        dense
+        v-model="newScheduleEntry.wallet"
+        type="text"
+        label="Pay using wallet"
+        :options="walletOptions()"
+      ></q-select>
+
+      <q-input
+        filled
+        dense
+        type="number"
+        v-model="newScheduleEntry.amount_sat"
+        label="Amount in satoshis"
+        placeholder=""
+      ></q-input>
+
+      <q-input
+        filled
+        dense
+        v-model.trim="newScheduleEntry.base_datetime"
+        label="First payment (YYYY-MM-DD HH:MM)"
+        placeholder=""
+      ></q-input>
+
+      <q-select
+        filled
+        dense
+        v-model="newScheduleEntry.repeat_freq"
+        type="text"
+        label="Then repeat every"
+        :options="scheduleFrequencyOptions"
+      ></q-select>
+
+      <q-input
+        filled
+        dense
+        v-model.trim="newScheduleEntry.lnurl"
+        label="LNURL code"
+        placeholder=""
+      ></q-input>
+
+      <q-btn
+        outline
+        color="blue"
+        class="text-center q-mb-md"
+        @click="submitNewScheduleEntry()"
+      >Schedule</q-btn>
+
+      {% endraw %}
+      <!-- <q-spinner
+        v-if="receive.status == 'loading'"
+        color="primary"
+        size="2.55em"
+      ></q-spinner> -->
+    </q-form>
+  </q-card-section>
+</q-card>
+{% endblock %}

--- a/lnbits/extensions/autopay/tests/test_basics.py
+++ b/lnbits/extensions/autopay/tests/test_basics.py
@@ -1,0 +1,20 @@
+import pytest
+
+from lnbits.extensions.autopay.utils import * 
+
+
+@pytest.mark.skip(reason="Requires 2 lnbits instances running")
+async def test_basic_lnurl_payment():
+    """ Does HTTP requests to LNBits."""
+    test_lnurl="LNURL1DP68GURN8GHJ7MR0VDSKC6R0WD6ZUMR0VDSKCER0D4SKJM36X5CRQVP0D3H82UNVWQHKZURF9AMRZTMVDE6HYMP0XURJK2EN"
+    wallet_alice1_id = "9e75ffeaee01409ab2f905dd8336f0ae"
+    wallet_dave1_id = "fe39ffc74ce7486fb76202f2c4cf58dc"
+
+
+    amount_msat = 100*1000
+    comment = ""
+    pay_info = await lnurl_scan(test_lnurl)
+    invoice = await lnurl_get_invoice(pay_info["callback"], amount_msat, comment, pay_info["description_hash"])
+    payment_hash = await pay_invoice_with_wallet(wallet_dave1_id, invoice["pr"], comment)
+
+    print("RESULT", payment_hash)

--- a/lnbits/extensions/autopay/tests/test_models.py
+++ b/lnbits/extensions/autopay/tests/test_models.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+
+from lnbits.extensions.autopay.models import *
+
+
+def test_ScheduleEntry_next_run():
+    for freq in REPEAT_FREQ_OPTIONS:
+        se = ScheduleEntry(0, "w", "t", datetime.now(), freq, "", 1000)
+        next = se.next_run(1)
+        assert next
+        assert type(next) == datetime

--- a/lnbits/extensions/autopay/tests/test_scheduler.py
+++ b/lnbits/extensions/autopay/tests/test_scheduler.py
@@ -1,0 +1,120 @@
+from lnbits.extensions.autopay.scheduler import *
+from lnbits.extensions.autopay.storage import InMemoryStorage
+from lnbits.extensions.autopay.models import *
+
+from datetime import datetime
+
+
+class MockPaymentExecutor:
+    def __init__(self):
+        self.calls = []
+
+    async def __call__(self, *args):
+        self.calls.append(args)
+        return f"hash_{args}"
+
+    def reset(self):
+        self.calls = []
+
+
+def dummyScheduleEntry(**kwargs):
+    se = ScheduleEntry(0, "wall", "dummy", datetime.now(), "hour", "LNURL", 1000)
+    return se._replace(**kwargs)
+
+
+async def test_Scheduler_basics():
+    st = InMemoryStorage()
+    mock = MockPaymentExecutor()
+    s = Scheduler(st, mock)
+
+    # 10th October, 10am
+    now_10am = datetime(2021, 10, 13, 10, 0, 0)
+    await s.run(now_10am)
+    assert len(st.payments) == 0
+    assert len(mock.calls) == 0
+
+    # this one runs weekly, 9am
+    now_9am = datetime(2021, 10, 13, 9, 0, 0)
+    se2 = dummyScheduleEntry(base_datetime=now_9am, repeat_freq="week", wallet_id="9am_wallet", amount_msat=3000)
+    await st.create_schedule_entry(se2)
+
+    now_8am = datetime(2021, 10, 13, 8, 0, 0)
+    await s.run(now_8am)
+    # SHOULD NOT RUN, too early
+    assert len(st.payments) == 0
+    assert len(mock.calls) == 0
+
+    await s.run(now_10am)
+    # SHOULD RUN
+    assert len(mock.calls) == 1
+    assert mock.calls[0][0] == "9am_wallet"
+    assert mock.calls[0][2] == 3000
+    assert len(st.payments) == 1
+
+    mock.reset()
+    await s.run(now_10am)
+    # SHOULD NOT run again
+    assert len(mock.calls) == 0
+    assert len(st.payments) == 1
+
+    now_nextweek = datetime(2021, 10, 20, 11, 0, 0)
+    await s.run(now_nextweek)
+    # SHOULD RUN
+    assert len(mock.calls) == 1
+    assert mock.calls[0][0] == "9am_wallet"
+    assert mock.calls[0][2] == 3000
+    assert len(st.payments) == 2
+
+
+async def test_Scheduler_hourly():
+    st = InMemoryStorage()
+    mock = MockPaymentExecutor()
+    s = Scheduler(st, mock)
+
+    now_9am = datetime(2021, 10, 13, 9, 0, 0)
+    se1 = dummyScheduleEntry(base_datetime=now_9am, repeat_freq="hour")
+    await st.create_schedule_entry(se1)
+
+    await s.run(datetime(2021, 10, 13, 8, 0, 0))
+    assert len(st.payments) == 0
+    assert len(mock.calls) == 0
+
+    await s.run(datetime(2021, 10, 13, 9, 10, 0))
+    assert len(st.payments) == 1
+    assert len(mock.calls) == 1
+
+    await s.run(datetime(2021, 10, 13, 10, 1, 0))
+    assert len(st.payments) == 2
+    assert len(mock.calls) == 2
+
+    await s.run(datetime(2021, 10, 13, 10, 20, 0))
+    assert len(st.payments) == 2
+    assert len(mock.calls) == 2
+
+    await s.run(datetime(2021, 10, 13, 11, 1, 0))
+    assert len(st.payments) == 3
+    assert len(mock.calls) == 3
+
+
+async def test_Scheduler_ignores_deleted_entries():
+    st = InMemoryStorage()
+    mock = MockPaymentExecutor()
+    s = Scheduler(st, mock)
+
+
+    now_9am = datetime(2021, 10, 13, 9, 0, 0)
+    now_10am = datetime(2021, 10, 13, 10, 0, 0)
+    se1 = dummyScheduleEntry(base_datetime=now_9am, repeat_freq="hour")
+    await st.create_schedule_entry(se1)
+    se1_id = (await st.read_schedule_entries())[0].id
+    assert se1_id > 0
+
+    # SHOULD RUN
+    await s.run(now_10am)
+    assert len(mock.calls) == 1
+    mock.reset()
+
+    # SHOULD NOT RUN
+    await st.delete_schedule_entry(se1_id)
+    await s.run(now_10am)
+    assert len(mock.calls) == 0

--- a/lnbits/extensions/autopay/tests/test_storage.py
+++ b/lnbits/extensions/autopay/tests/test_storage.py
@@ -1,0 +1,139 @@
+from lnbits.extensions.autopay.storage import SqliteStorage, InMemoryStorage
+from lnbits.extensions.autopay.models import *
+from lnbits.extensions.autopay import migrations
+
+from datetime import datetime
+import re
+
+import pytest
+import asyncio
+import trio
+
+
+migration_fn_matcher = re.compile(r"^m(\d\d\d)_")
+
+
+def create_lnbits_db(tmp_path, db_name="ext_autopay"):
+    """ Monkey patch data path where the sqlite file will be created and initialize the db. """
+    import lnbits.db
+    _LNBITS_DATA_FOLDER = lnbits.db.LNBITS_DATA_FOLDER
+    lnbits.db.LNBITS_DATA_FOLDER = tmp_path
+    db = lnbits.db.Database(db_name)
+    lnbits.db.LNBITS_DATA_FOLDER = _LNBITS_DATA_FOLDER
+    return db
+
+
+async def create_mock_sqlite_storage(tmp_path):
+    """ Create dummy sqlite.db for each test. Can be configured with --basetemp pytest argument. """
+    db = create_lnbits_db(tmp_path)
+
+    # Run migrations
+    for key, migrate in migrations.__dict__.items():
+        match = migration_fn_matcher.match(key)
+        if match: await migrate(db)
+
+    return SqliteStorage(db)
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+def storage(request, tmp_path):
+    """ Each test with this argument will be run twice: once for InMemoryStorage, once for SqliteStorage. """
+    if request.param == "memory":
+        return InMemoryStorage()
+    elif request.param == "sqlite":
+        return trio.run(create_mock_sqlite_storage, tmp_path)
+
+
+def dummyScheduleEntry(**kwargs):
+    se = ScheduleEntry(0, "wall", "dummy", datetime.now(), "hour", "LNURL", 1000)
+    return se._replace(**kwargs)
+
+
+async def test_Storage_schedule_entries_basics(storage):
+    s = storage
+
+    assert len(await s.read_schedule_entries()) == 0
+
+    se1 = dummyScheduleEntry()
+    await s.create_schedule_entry(se1)
+    assert len(await s.read_schedule_entries()) == 1
+
+    se2 = dummyScheduleEntry()
+    await s.create_schedule_entry(se2)
+    assert len(await s.read_schedule_entries()) == 2
+
+
+async def test_Storage_payments_basics(storage):
+    s = storage
+
+    await s.create_schedule_entry(dummyScheduleEntry())
+    await s.create_schedule_entry(dummyScheduleEntry())
+    se1, se2 = await s.read_schedule_entries()
+
+    assert await s.read_payment_count(se1.id) == 0
+    assert await s.read_payment_count(se2.id) == 0
+    
+    pe1 = PaymentLogEntry(0, se1.id, 123, "dummyhash")
+    await s.create_payment_log(pe1)
+    assert await s.read_payment_count(se1.id) == 1
+    assert await s.read_payment_count(se2.id) == 0
+
+    pe2 = PaymentLogEntry(0, se2.id, 124, "dummyhash2")
+    await s.create_payment_log(pe2)
+    assert await s.read_payment_count(se1.id) == 1
+    assert await s.read_payment_count(se2.id) == 1
+
+    pes = await s.read_payment_log_entries(se1.id)
+    assert len(pes) == 1
+    assert pes[0].payment_hash == "dummyhash"
+
+    pes = await s.read_payment_log_entries(se2.id)
+    assert len(pes) == 1
+    assert pes[0].payment_hash == "dummyhash2"
+
+
+async def test_Storage_increment_ids(storage):
+    s = storage
+
+    assert len(await s.read_schedule_entries()) == 0
+
+    se1 = dummyScheduleEntry()
+    await s.create_schedule_entry(se1)
+    await s.create_schedule_entry(se1)
+
+    ses = await s.read_schedule_entries()
+    assert len(ses) == 2
+    assert ses[0].id > 0
+    assert ses[1].id > 0
+    assert ses[0].id != ses[1].id
+
+
+async def test_Storage_delete_schedule_entry(storage):
+    s = storage
+
+    se1 = dummyScheduleEntry()
+    await s.create_schedule_entry(se1)
+    ses = await s.read_schedule_entries()
+    assert len(ses) == 1
+
+    await s.delete_schedule_entry(ses[0].id)
+    assert len(await s.read_schedule_entries()) == 0
+
+
+async def test_SqliteStorage_model_types(tmp_path):
+    s = await create_mock_sqlite_storage(tmp_path)
+
+    se = dummyScheduleEntry(base_datetime=datetime(2021, 10, 13))
+    await s.create_schedule_entry(se)
+
+    ses = await s.read_schedule_entries()
+    assert len(ses) == 1
+    se = ses[0]
+
+    assert type(se.base_datetime) is datetime
+    assert se.base_datetime.year == 2021
+    assert se.base_datetime.month == 10
+    assert se.base_datetime.day == 13
+
+    dt = se.next_run(already_executed_count=1)
+    assert type(dt) is datetime

--- a/lnbits/extensions/autopay/tests/test_views.py
+++ b/lnbits/extensions/autopay/tests/test_views.py
@@ -1,0 +1,174 @@
+import pytest
+import json
+
+from datetime import datetime, timedelta
+
+from lnbits.app import create_app
+from lnbits.extensions.autopay import context as autopay_context
+from lnbits.extensions.autopay.storage import InMemoryStorage
+from lnbits.extensions.autopay.utils import lnurl_scan as real_lnurl_scan
+
+
+def mock_lnurl_scan(returns={"minSendable": 1, "maxSendable": 100000}):
+    async def mock_lnurl_scan_(code): return returns
+    return mock_lnurl_scan_
+
+
+@pytest.fixture
+async def client():
+    # register routes, otherwise they are not loaded during pytest
+    from lnbits.extensions.autopay.views_api import api_autopay_schedule_get
+
+    app = create_app()
+    app.config["TESTING"] = True
+
+    async with app.test_client() as client:
+        client.preserve_context = False
+        yield client
+
+
+@pytest.fixture
+def context():
+    c = autopay_context
+    # Each test gets fresh storage
+    c.storage = InMemoryStorage()
+    c.lnurl_scan = mock_lnurl_scan()
+    return c
+
+
+def valid_schedule_data():
+    future_dt = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d %H:%M")
+    return {"title": "Foo", "wallet_id": "TBD", "base_datetime": future_dt, "repeat_freq": "hour", "lnurl": "dummy", "amount_msat": 2000}
+
+
+async def test_api_get_schedule(client, context):
+    from lnbits.extensions.autopay.models import ScheduleEntry, PaymentLogEntry
+
+    s = context.storage
+    await s.create_schedule_entry(ScheduleEntry(1, "dummywallet1", "title1", datetime.now(), "week", "urlcode", 2000))
+    await s.create_payment_log(PaymentLogEntry(0, 1, 123, "h"))
+    await s.create_payment_log(PaymentLogEntry(1, 1, 123, "h"))
+
+    r = await client.get("/autopay/api/v1/schedule")
+    rr = await r.get_data()
+    d = json.loads(rr)
+
+    assert "schedule" in d
+    assert len(d["schedule"]) == 1
+    assert d["schedule"][0]["wallet_id"] == "dummywallet1"
+    assert d["schedule"][0]["amount_msat"] == 2000
+
+    assert len(d["schedule"][0]["payments"]) == 2
+    assert d["schedule"][0]["payments"][0]["payment_hash"] == "h"
+    assert "next_payment" in d["schedule"][0]
+
+
+async def test_api_post_schedule(client, context):
+    new_schedule = valid_schedule_data()
+    r = await client.post("/autopay/api/v1/schedule", json=new_schedule)
+    d = json.loads(await r.get_data())
+    assert r.status_code == 201
+    assert len(await context.storage.read_schedule_entries()) == 1
+
+
+async def test_api_post_schedule_validation(client, context):
+    async def create(new_schedule):
+        r = await client.post("/autopay/api/v1/schedule", json=new_schedule)
+        d = json.loads(await r.get_data())
+        return r.status_code, d
+
+    # Valid
+    s = valid_schedule_data()
+    code, data = await create(s)
+    assert code == 201
+
+    # Missing title
+    s = valid_schedule_data()
+    s["title"] = None
+    code, data = await create(s)
+    assert code == 400
+    assert "title" in data["message"]
+
+    # Invalid repaet freq
+    s = valid_schedule_data()
+    s["repeat_freq"] = "invalid"
+    code, data = await create(s)
+    assert code == 400
+    assert "repeat_freq" in data["message"]
+
+    # Incorrect base_datetime format
+    s = valid_schedule_data()
+    s["base_datetime"] = "foo"
+    code, data = await create(s)
+    assert code == 400
+    assert "base_datetime" in data["message"]
+
+    # Not future datetime
+    dt = (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
+    s = valid_schedule_data()
+    s["base_datetime"] = dt
+    code, data = await create(s)
+    assert code == 400
+    assert "base_datetime" in data["message"]
+
+    # Missing amount
+    s = valid_schedule_data()
+    s["amount_msat"] = None
+    code, data = await create(s)
+    assert code == 400
+    assert "amount_msat" in data["message"]
+
+    # Amount not within min/max from lnurl
+    context.lnurl_scan = mock_lnurl_scan({"minSendable": 10000, "maxSendable": 200000})
+    s = valid_schedule_data()
+    s["amount_msat"] = 100  # too small
+    code, data = await create(s)
+    assert code == 400
+    assert "amount_msat" in data["message"]
+
+    s = valid_schedule_data()
+    s["amount_msat"] = 200001  # too large
+    code, data = await create(s)
+    assert code == 400
+    assert "amount_msat" in data["message"]
+
+    # Amount within - valid
+    s = valid_schedule_data()
+    s["amount_msat"] = 10000
+    code, data = await create(s)
+    assert code == 201
+
+    # Invalid lnurl code
+    context.lnurl_scan = real_lnurl_scan
+    s = valid_schedule_data()
+    s["lnurl"] = "invalid"
+    code, data = await create(s)
+    assert code == 400
+    assert "lnurl" in data["message"]
+
+
+async def test_api_post_delete_schedule(client, context):
+    # Create new schedule entry
+    new_schedule = valid_schedule_data()
+    r = await client.post("/autopay/api/v1/schedule", json=new_schedule)
+    d = json.loads(await r.get_data())
+    assert r.status_code == 201
+
+    # Test it's there through API
+    r = await client.get("/autopay/api/v1/schedule")
+    d = json.loads(await r.get_data())
+    assert "schedule" in d
+    assert len(d["schedule"]) == 1
+
+    # Delete it
+    schedule_id = d["schedule"][0]["id"]
+    r = await client.delete(f"/autopay/api/v1/schedule/{schedule_id}")
+    d = json.loads(await r.get_data())
+    assert r.status_code == 200
+    assert len(await context.storage.read_schedule_entries()) == 0
+
+
+async def test_api_scheduler(client, context):
+    r = await client.post("/autopay/api/v1/scheduler")
+    # d = json.loads(await r.get_data())
+    assert r.status_code == 200

--- a/lnbits/extensions/autopay/utils.py
+++ b/lnbits/extensions/autopay/utils.py
@@ -1,0 +1,117 @@
+import json
+import hashlib
+import httpx
+from urllib.parse import urlparse
+
+from lnbits import bolt11, lnurl
+from lnbits.core.services import pay_invoice
+
+
+async def lnurl_scan(code: str):
+    """ Decode given LNURL code, and get callback for creating invoices.
+    
+    Returns dict(callback, description_hash, min/maxSendable)
+    Raises if not payRequest type.
+
+    NOTE: mostly copied logic from core/views/api.py api_lnurlscan()
+    """
+
+    url = lnurl.decode(code)
+
+    if "tag=login" in url:
+        raise ValueError("Only `payRequest` LNURL supported.")
+
+    async with httpx.AsyncClient() as client:
+        r = await client.get(url, timeout=5)
+        if r.is_error:
+            raise Exception("Failed to get LNURL parameters from {url}")
+
+        data = json.loads(r.text)
+
+        if data["tag"] == "payRequest":
+            result = data.copy()
+
+            result.update(
+                description_hash=hashlib.sha256(
+                    data["metadata"].encode("utf-8")
+                ).hexdigest()
+            )
+            metadata = json.loads(data["metadata"])
+            for [k, v] in metadata:
+                if k == "text/plain":
+                    result.update(description=v)
+                if k == "image/jpeg;base64" or k == "image/png;base64":
+                    data_uri = "data:" + k + "," + v
+                    result.update(image=data_uri)
+                if k == "text/email" or k == "text/identifier":
+                    result.update(targetUser=v)
+
+            result.update(commentAllowed=data.get("commentAllowed", 0))
+
+            return result
+
+        else:
+            raise ValueError("Only `payRequest` LNURL supported.")
+
+
+async def lnurl_get_invoice(callback, amount_msat, comment, description_hash):
+    """ Gets the invoice params, by calling given LNURL callback.
+    
+    This needs to be called before every payment, to generate new invoice.
+    Returns dict(pr=payment request/invoice, successAction)
+    Raises if invoice invalid.
+    """
+
+    domain = urlparse(callback).netloc
+    async with httpx.AsyncClient() as client:
+        r = await client.get(
+            callback,
+            params={"amount": amount_msat, "comment": comment},
+            timeout=40,
+        )
+        if r.is_error:
+            raise httpx.ConnectError
+
+    result = json.loads(r.text)
+    if result.get("status") == "ERROR":
+        raise Exception(f"Failed to get invoice from {domain}: {result.get('reason', '')}")
+
+    invoice = bolt11.decode(result["pr"])
+
+    if invoice.amount_msat != amount_msat:
+        raise ValueError(f"{domain} returned an invalid invoice. Expected {amount_msat} msat, got {invoice.amount_msat}.")
+
+    if invoice.description_hash != description_hash:
+        raise ValueError(f"{domain} returned an invalid invoice. Expected description_hash == {description_hash}, got {invoice.description_hash}.")
+
+    return result
+
+
+async def pay_invoice_with_wallet(wallet_id, payment_request, comment=None, success_action=None):
+    """ Actually pay given invoice, using given LNBits wallet.
+
+    Returns payment hash.
+    """
+
+    extra = {}
+
+    if success_action:
+        extra["success_action"] = params["successAction"]
+    if comment:
+        extra["comment"] = comment
+
+    payment_hash = await pay_invoice(
+        wallet_id=wallet_id,
+        payment_request=payment_request,
+        description="",
+        extra=extra,
+    )
+
+    return payment_hash
+
+
+async def execute_lnurl_payment(wallet_id, lnurl_code,  amount_msat, comment=None):
+    info = await lnurl_scan(lnurl_code)
+    invoice = await lnurl_get_invoice(info["callback"], amount_msat, comment, info["description_hash"])
+    payment_hash = await pay_invoice_with_wallet(wallet_id, invoice["pr"], comment)
+    return payment_hash

--- a/lnbits/extensions/autopay/views.py
+++ b/lnbits/extensions/autopay/views.py
@@ -1,0 +1,11 @@
+from quart import render_template, g
+from lnbits.decorators import check_user_exists, validate_uuids
+
+from . import autopay_ext
+
+
+@autopay_ext.route("/")
+@validate_uuids(["usr"], required=True)
+@check_user_exists()
+async def index():
+    return await render_template("autopay/index.html", user=g.user)

--- a/lnbits/extensions/autopay/views_api.py
+++ b/lnbits/extensions/autopay/views_api.py
@@ -1,0 +1,80 @@
+from quart import g, jsonify, request
+from lnbits.decorators import api_validate_post_request
+
+from http import HTTPStatus
+from datetime import datetime
+import json
+
+from . import autopay_ext, context
+from .models import ScheduleEntry, PaymentLogEntry
+from .scheduler import Scheduler
+from .utils import lnurl_scan
+from .storage import SqliteStorage
+
+
+
+
+@autopay_ext.route("/api/v1/scheduler", methods=["POST"])
+async def api_scheduler():
+    s = context.get_scheduler()
+    await s.run(datetime.now())
+
+    return jsonify({"status": "success"}), HTTPStatus.OK
+
+
+@autopay_ext.route("/api/v1/schedule", methods=["GET"])
+async def api_autopay_schedule_get():
+    storage = context.storage
+    r = []
+    for se in await storage.read_schedule_entries():
+        s_dict = dict(se._asdict())
+        ps = await storage.read_payment_log_entries(se.id)
+        s_dict["payments"] = [dict(p._asdict()) for p in ps]
+        s_dict["next_payment"] = str(se.next_run(await storage.read_payment_count(se.id)))
+        r.append(s_dict)
+
+    return jsonify({"schedule": r}), HTTPStatus.OK
+
+
+@autopay_ext.route("/api/v1/schedule", methods=["POST"])
+@api_validate_post_request(
+    schema={
+        "title": {"type": "string", "empty": False, "required": True},
+        "wallet_id": {"type": "string", "empty": False, "required": True},
+        "base_datetime": {"type": "string", "empty": False, "required": True},
+        "repeat_freq": {"type": "string", "empty": False, "required": True},
+        "lnurl": {"type": "string", "empty": False, "required": True},
+        "amount_msat": {"type": "integer", "required": True}
+    }
+)
+async def api_autopay_schedule_post():
+    d = json.loads(await request.get_data())
+
+    # Validate
+    errors = []
+    ScheduleEntry.validate_base_datetime(d["base_datetime"], errors)
+    ScheduleEntry.validate_repeat_freq(d["repeat_freq"], errors)
+    try:
+        lnurl_params = await context.lnurl_scan(d["lnurl"])
+        if d["amount_msat"] < lnurl_params["minSendable"]:
+            errors.append(f"'amount_msat' must be at least {lnurl_params['minSendable']} to pay this LNURL")
+        if d["amount_msat"] > lnurl_params["maxSendable"]:
+            errors.append(f"'amount_msat' must be at max {lnurl_params['maxSendable']} to pay this LNURL")
+    except (AssertionError, ValueError) as e:
+        errors.append(f"'lnurl' invalid: {e}")
+
+    if len(errors) > 0:
+        return jsonify({"message": f"Errors in request data: {errors}"}), HTTPStatus.BAD_REQUEST,
+
+    se = ScheduleEntry.from_request(d)
+
+    await context.storage.create_schedule_entry(se)
+
+    return jsonify({"status": "success",}), HTTPStatus.CREATED
+
+
+@autopay_ext.route("/api/v1/schedule/<int:schedule_id>", methods=["DELETE"])
+async def api_autopay_schedule_delete(schedule_id: int):
+    await context.storage.delete_schedule_entry(schedule_id)
+
+    return jsonify({"status": "success",}), HTTPStatus.OK


### PR DESCRIPTION
**What is this extension?**
You can schedule repeated payments in the future, using LNURL (type
payRequest): add LNURL, with amount, future datetime and repeating frequency (hourly, daily, weekly), and LNBits will execute the payments.

**Feedback for this PR - potential issues:**
- Currently the scheduling is done by spawning a process that hits the webserver with curl. This is not great, likely doesn't work with Tor. I tried really hard to make this work with Quart/asyncio (just put fn on the event loop that will get called every x seconds/minutes, but I couldn't figure it out). Once LNBits updates to Quart 0.16, [this](https://stackoverflow.com/questions/70075859/scheduling-periodic-function-call-in-quart-asyncio/70086619#70086619) should work, hopefully.
- I mostly wanted to learn how LNBits work, and wanted this functionality so that I can setup automatic saving/allowance for my kids. I've never used Quart/Trio/Vue/Quasar/etc before so likely it's not following best practices. Please let me know, or even better just send improvements.


End-to-end tested locally with Polar.



