### PR TITLE
Add email notification capabilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,16 @@ LNTXBOT_KEY=LNTXBOT_ADMIN_KEY
 # OpenNodeWallet
 OPENNODE_API_ENDPOINT=https://api.opennode.com/
 OPENNODE_KEY=OPENNODE_ADMIN_KEY
+
+# Enable Email services. For busy servers use sendgrid as an email provider. 
+# Using a consumer mail provider with large volumes of mails will get you kicked.
+# Options "sendgrid" or "smtp"
+
+# If you enable email you'll need to install aiosmtplib: "pip install aiosmtplib"
+# EMAIL_PROVIDER="smtp"
+# EMAIL_SENDER="lnbits@localhost"
+
+# SMTP_URL="mail.privateemail.com"
+# SMTP_PORT=465
+# SMTP_LOGIN="smtp_login"
+# SMTP_PASSWORD="smtp_password"

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -59,3 +59,12 @@ try:
     )
 except:
     LNBITS_COMMIT = "unknown"
+
+EMAIL_PROVIDER: str = env.str("EMAIL_PROVIDER", default=None)
+EMAIL_ENABLED: bool = EMAIL_PROVIDER != None
+EMAIL_SENDER: str = env.str("EMAIL_SENDER", default="")
+
+SMTP_URL: str = env.str("SMTP_URL", default=None)
+SMTP_PORT: int = env.int("SMTP_PORT", 0)
+SMTP_LOGIN: str = env.str("SMTP_LOGIN", default=None)
+SMTP_PASSWORD: str = env.str("SMTP_PASSWORD", default=None)

--- a/lnbits/utils/send_mail.py
+++ b/lnbits/utils/send_mail.py
@@ -1,0 +1,54 @@
+import asyncio
+from email.message import EmailMessage
+
+import aiosmtplib
+
+from lnbits import settings as s
+
+
+async def _send_mail_worker(mail: EmailMessage):
+    mail["From"] = s.EMAIL_SENDER
+    resp = await aiosmtplib.send(
+        message=mail,
+        hostname=s.SMTP_URL,
+        port=s.SMTP_PORT,
+        use_tls=True,
+        username=s.SMTP_LOGIN,
+        password=s.SMTP_PASSWORD,
+    )
+    return resp
+
+
+async def send_mail_async(mail: EmailMessage):
+    """Attempts to send an email and returns the result.
+
+    Parameters
+    ----------
+    mail : [email.message.EmailMessage]
+        [EmailMessage] from the email package
+    """
+
+    if not s.EMAIL_ENABLED:
+        raise RuntimeError("LNBits Email system disabled")
+
+    resp = await _send_mail_worker(mail)
+    return resp
+
+
+def send_mail_best_effort(mail: EmailMessage):
+    """Fire and forget email sending.
+
+    Will not return any errors
+    Use this if you don't really care if the mail was sent or not.
+
+    Parameters
+    ----------
+    mail: [email.message.EmailMessage]
+        [email.message.EmailMessage] from the email package
+    """
+
+    if not s.EMAIL_ENABLED:
+        raise RuntimeError("LNBits Email system disabled")
+
+    loop = asyncio.get_event_loop()
+    loop.create_task(_send_mail_worker(mail))


### PR DESCRIPTION
This PR adds capabilities to send notification email to a user provided email address.

**Why?**
* user might want to get notified when a subscription must be renewed (e.g. lnaddress)
* warn the user when funds are low in case he has some automatic recurring payments running

**How?**
Email support will be **completely optional** and is **opt-in**. If a user doesn't want to set his email then he doesn't have to. Settings will be stored in the .env file and can be disabled there. When email is disabled, no new extensions are necessary.

We have these possible states:
- Globaly disabled - must be disabled in the UI
- Globally enabled but users will be able to turn this on and off at will

To reduce UI clutter there should only be one way to manage the email address:
![image](https://user-images.githubusercontent.com/503952/144722819-6228ce80-bb68-4dca-ab23-7a51c73bfc06.png)

The users profile page can be a whole new page or just a Modal depending on the amount of settings there are.

TODOS:
- [x] implement send via SMTP 
- [ ] implement send via [SendGrid](https://sendgrid.com)
- [ ] add email notifications to LNbits core where appropriate (ideas welcome!)
- [ ] implement an API to verify email addresses
- [ ] charge an optional fee for this service if enabled for a wallet
