### PR TITLE
Added sats support for lnurlpos extension

### DIFF
--- a/lnbits/extensions/lnurlpos/lnurl.py
+++ b/lnbits/extensions/lnurlpos/lnurl.py
@@ -114,7 +114,7 @@ async def lnurl_v1_params(
 
     price_msat = (
         await fiat_amount_as_satoshis(float(amount_in_cent) / 100, pos.currency)
-        if pos.currency != "sat"
+        if pos.currency.lower() != "sats"
         else amount_in_cent
     ) * 1000
 

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -124,6 +124,7 @@ currencies = {
     "RUB": "Russian Ruble",
     "RWF": "Rwandan Franc",
     "SAR": "Saudi Riyal",
+    "sats": "Satoshis",
     "SBD": "Solomon Islands Dollar",
     "SCR": "Seychellois Rupee",
     "SEK": "Swedish Krona",


### PR DESCRIPTION
"sats" is intentionally lowercased and four characters long in the exchange_rate.py file. 