### PR TITLE
2% reserve only for external payments

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -95,9 +95,7 @@ async def pay_invoice(
         if max_sat and invoice.amount_msat > max_sat * 1000:
             raise ValueError("Amount in invoice is too high.")
 
-        wallet = await get_wallet(wallet_id, conn=conn)
-        if invoice.amount_msat > wallet.balance_msat - (wallet.balance_msat / 100 * 2):
-            raise PermissionError("LNbits requires you keep at least 2% reserve to cover potential routing fees.")
+        wallet = await get_wallet(wallet_id, conn=conn)   
 
         # put all parameters that don't change here
         PaymentKwargs = TypedDict(
@@ -141,11 +139,17 @@ async def pay_invoice(
                 **payment_kwargs,
             )
 
-        # do the balance check
-        wallet = await get_wallet(wallet_id, conn=conn)
-        assert wallet
-        if wallet.balance_msat < 0:
-            raise PermissionError("Insufficient balance.")
+        # do the balance check if internal payment
+        if internal_checking_id:
+            wallet = await get_wallet(wallet_id, conn=conn)   
+            assert wallet
+            if wallet.balance_msat < 0:
+                raise PermissionError("Insufficient balance.")
+
+        # do the balance check if external payment
+        else:
+            if invoice.amount_msat > wallet.balance_msat - (wallet.balance_msat / 100 * 2):
+                raise PermissionError("LNbits requires you keep at least 2% reserve to cover potential routing fees.")  
 
     if internal_checking_id:
         # mark the invoice from the other side as not pending anymore


### PR DESCRIPTION
Doesn't have reason to reserve 2% of the payment on internal payments, since there's no routing fees.