### PR TITLE
Upgrade conversion endpoint

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -516,12 +516,13 @@ class ConversionData(BaseModel):
 async def api_fiat_as_sats(data: ConversionData):
     output = {}
     if data.unit == 'sat':
-        output["sats"] = data.amount
+        output["sats"] = int(data.amount)
         output["BTC"] = data.amount / 100000000
         for currency in data.to.split(','):            
             output[currency.strip().upper()] = await satoshis_amount_as_fiat(data.amount, currency.strip())
         return output
     else:
+        output[data.unit.upper()] = data.amount
         output["sats"] = await fiat_amount_as_satoshis(data.amount, data.to)
         output["BTC"] = output["sats"] / 100000000
         return output

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -284,3 +284,6 @@ async def get_fiat_rate_satoshis(currency: str) -> float:
 
 async def fiat_amount_as_satoshis(amount: float, currency: str) -> int:
     return int(amount * (await get_fiat_rate_satoshis(currency)))
+
+async def satoshis_amount_as_fiat(amount: float, currency: str) -> float:
+    return float(amount / (await get_fiat_rate_satoshis(currency)))


### PR DESCRIPTION
small upgrade to conversion endpoint to allow fiat -> sats and sats -> fiat

also allow to pass a list of currencies to get converted

updated data schema:
`{unit: <string defaults to 'sat'>, amount: <float>, to: <string defaults to 'usd'>}`
sats -> fiat
`{"amount": 30000, "to": "eur, gbp"}`
fiat -> sat
`{"amount": 10, "unit": "eur"}`