### PR TITLE
LNDHhub for fastapi with LIMIT

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -217,6 +217,7 @@ async def get_payments(
     incoming: bool = False,
     since: Optional[int] = None,
     exclude_uncheckable: bool = False,
+    limit: Optional[int] = None,
     conn: Optional[Connection] = None,
 ) -> List[Payment]:
     """
@@ -261,6 +262,9 @@ async def get_payments(
         clause.append("checking_id NOT LIKE 'temp_%'")
         clause.append("checking_id NOT LIKE 'internal_%'")
 
+    # TODO: add support for pagination
+    limit_clause = f"LIMIT {limit}" if type(limit) == int and limit > 0 else ""
+
     where = ""
     if clause:
         where = f"WHERE {' AND '.join(clause)}"
@@ -271,6 +275,7 @@ async def get_payments(
         FROM apipayments
         {where}
         ORDER BY time DESC
+        {limit_clause}
         """,
         tuple(args),
     )

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -61,7 +61,9 @@ async def get_user(user_id: str, conn: Optional[Connection] = None) -> Optional[
         email=user["email"],
         extensions=[e[0] for e in extensions],
         wallets=[Wallet(**w) for w in wallets],
-        admin=user["id"] in [x.strip() for x in LNBITS_ADMIN_USERS] if LNBITS_ADMIN_USERS else False
+        admin=user["id"] in [x.strip() for x in LNBITS_ADMIN_USERS]
+        if LNBITS_ADMIN_USERS
+        else False,
     )
 
 
@@ -218,6 +220,7 @@ async def get_payments(
     since: Optional[int] = None,
     exclude_uncheckable: bool = False,
     limit: Optional[int] = None,
+    offset: Optional[int] = None,
     conn: Optional[Connection] = None,
 ) -> List[Payment]:
     """
@@ -262,8 +265,14 @@ async def get_payments(
         clause.append("checking_id NOT LIKE 'temp_%'")
         clause.append("checking_id NOT LIKE 'internal_%'")
 
-    # TODO: add support for pagination
     limit_clause = f"LIMIT {limit}" if type(limit) == int and limit > 0 else ""
+    offset_clause = f"OFFSET {offset}" if type(offset) == int and offset > 0 else ""
+    # combine limit and offset clauses
+    limit_offset_clause = (
+        f"{limit_clause} {offset_clause}"
+        if limit_clause and offset_clause
+        else limit_clause or offset_clause
+    )
 
     where = ""
     if clause:
@@ -275,11 +284,10 @@ async def get_payments(
         FROM apipayments
         {where}
         ORDER BY time DESC
-        {limit_clause}
+        {limit_offset_clause}
         """,
         tuple(args),
     )
-
     return [Payment.from_row(row) for row in rows]
 
 

--- a/lnbits/extensions/lndhub/views_api.py
+++ b/lnbits/extensions/lndhub/views_api.py
@@ -13,7 +13,7 @@ from lnbits import bolt11
 from lnbits.core.crud import delete_expired_invoices, get_payments
 from lnbits.core.services import create_invoice, pay_invoice
 from lnbits.decorators import WalletTypeInfo
-from lnbits.settings import WALLET
+from lnbits.settings import WALLET, LNBITS_SITE_TITLE
 
 from . import lndhub_ext
 from .decorators import check_wallet, require_admin_key
@@ -57,7 +57,7 @@ async def lndhub_addinvoice(
         _, pr = await create_invoice(
             wallet_id=wallet.wallet.id,
             amount=int(data.amt),
-            memo=data.memo or "received sats",
+            memo=data.memo or LNBITS_SITE_TITLE,
             extra={"tag": "lndhub"},
         )
     except:

--- a/lnbits/extensions/lndhub/views_api.py
+++ b/lnbits/extensions/lndhub/views_api.py
@@ -119,6 +119,7 @@ async def lndhub_balance(
 async def lndhub_gettxs(
     wallet: WalletTypeInfo = Depends(check_wallet),
     limit: int = Query(20, ge=1, le=20),
+    offset: int = Query(0, ge=0),
 ):
     for payment in await get_payments(
         wallet_id=wallet.wallet.id,
@@ -127,6 +128,7 @@ async def lndhub_gettxs(
         outgoing=True,
         incoming=False,
         limit=limit,
+        offset=offset,
         exclude_uncheckable=True,
     ):
         await payment.set_pending(
@@ -154,6 +156,7 @@ async def lndhub_gettxs(
                     outgoing=True,
                     incoming=False,
                     limit=limit,
+                    offset=offset,
                 )
             )
         )
@@ -164,6 +167,7 @@ async def lndhub_gettxs(
 async def lndhub_getuserinvoices(
     wallet: WalletTypeInfo = Depends(check_wallet),
     limit: int = Query(20, ge=1, le=20),
+    offset: int = Query(0, ge=0),
 ):
     for invoice in await get_payments(
         wallet_id=wallet.wallet.id,
@@ -172,6 +176,7 @@ async def lndhub_getuserinvoices(
         outgoing=False,
         incoming=True,
         limit=limit,
+        offset=offset,
         exclude_uncheckable=True,
     ):
         await invoice.set_pending(
@@ -201,6 +206,7 @@ async def lndhub_getuserinvoices(
                     incoming=True,
                     outgoing=False,
                     limit=limit,
+                    offset=offset,
                 )
             )
         )

--- a/lnbits/extensions/lndhub/views_api.py
+++ b/lnbits/extensions/lndhub/views_api.py
@@ -88,7 +88,8 @@ async def lndhub_payinvoice(
             extra={"tag": "lndhub"},
         )
     except:
-        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Payment failed")
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND,
+                            detail="Payment failed")
 
     invoice: bolt11.Invoice = bolt11.decode(r_invoice.invoice)
 
@@ -116,7 +117,7 @@ async def lndhub_balance(
 
 @lndhub_ext.get("/ext/gettxs")
 async def lndhub_gettxs(
-    wallet: WalletTypeInfo = Depends(check_wallet), limit: int = Query(0, ge=0, lt=200)
+    wallet: WalletTypeInfo = Depends(check_wallet), limit: int = Query(0, ge=0, lt=20)
 ):
     for payment in await get_payments(
         wallet_id=wallet.wallet.id,
@@ -124,6 +125,7 @@ async def lndhub_gettxs(
         pending=True,
         outgoing=True,
         incoming=False,
+        limit=limit,
         exclude_uncheckable=True,
     ):
         await payment.set_pending(
@@ -148,23 +150,24 @@ async def lndhub_gettxs(
                     complete=True,
                     outgoing=True,
                     incoming=False,
+                    limit=limit,
                 )
-            )[:limit]
+            )
         )
     ]
 
 
 @lndhub_ext.get("/ext/getuserinvoices")
 async def lndhub_getuserinvoices(
-    wallet: WalletTypeInfo = Depends(check_wallet), limit: int = Query(0, ge=0, lt=200)
+    wallet: WalletTypeInfo = Depends(check_wallet), limit: int = Query(0, ge=0, lt=20)
 ):
-    await delete_expired_invoices()
     for invoice in await get_payments(
         wallet_id=wallet.wallet.id,
         complete=False,
         pending=True,
         outgoing=False,
         incoming=True,
+        limit=limit,
         exclude_uncheckable=True,
     ):
         await invoice.set_pending(
@@ -192,8 +195,9 @@ async def lndhub_getuserinvoices(
                     complete=True,
                     incoming=True,
                     outgoing=False,
+                    limit=limit,
                 )
-            )[:limit]
+            )
         )
     ]
 


### PR DESCRIPTION
**Description**
* This PR adds a `limit` clause to the `get_payments` crud in order to ... limit the number of payments to receive from the db. 
* This is necessary since the `lndhub` extension used to requests all payments of a user and just sliced returned list (very inefficient). 
* The default number of tx's to receive is set from 200 to 20, because more is usually not needed and the client can still request more if they like. 
* It also removes the unnecessary `delete_expired_invoices()` which went through _all_ invoices and checked with the backend previously. 

**Comments:**
* Add pagination to the crud as well? This would certainly come handy for the web interface which does not need to fetch all transactions if they are not shown anyway. 

**Todo:**
* [x] Testing
* [x] Check whether `get_payments` on `fastapi` still works with lndhub since it expected a `list` on quart but now gets a `dict`. I had some issues before. 

**Info:** Ready to merge!