### PR TITLE
api: Fix conversion from fiat to satoshis

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -559,6 +559,6 @@ async def api_fiat_as_sats(data: ConversionData):
         return output
     else:
         output[data.from_.upper()] = data.amount
-        output["sats"] = await fiat_amount_as_satoshis(data.amount, data.to)
+        output["sats"] = await fiat_amount_as_satoshis(data.amount, data._from)
         output["BTC"] = output["sats"] / 100000000
         return output


### PR DESCRIPTION
Conversion to satoshis incorrectly used data.to as fiat currency rather
than data._from.

Note: The api currently assumes you are either converting to or from satoshis. This could be fixed to allow arbitrary conversions, so I will add that if needed.