### PR TITLE
Add env var as admin password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ LNBITS_ADMIN_USERS=""
 # Extensions only admin can access
 LNBITS_ADMIN_EXTENSIONS="ngrok"
 LNBITS_DEFAULT_WALLET_NAME="LNbits wallet"
+# If this is set, it can be provided at login to make your user an admin
+LNBITS_ADMIN_LOGIN_KEY=""
 
 # Disable extensions for all users, use "all" to disable all extensions
 LNBITS_DISABLED_EXTENSIONS="amilk"

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -84,7 +84,7 @@ async def get_user(user_id: str, conn: Optional[Connection] = None) -> Optional[
         wallets=[Wallet(**w) for w in wallets],
         admin=user["id"] in [x.strip() for x in LNBITS_ADMIN_USERS]
         if LNBITS_ADMIN_USERS
-        else user["admin"],
+        else (user["admin"] or False),
     )
 
 

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -15,9 +15,17 @@ from .models import User, Wallet, Payment, BalanceCheck
 # --------
 
 
-async def create_account(*, is_admin: Optional[bool] = False, conn: Optional[Connection] = None) -> User:
+async def create_account(
+    *, is_admin: Optional[bool] = False, conn: Optional[Connection] = None
+) -> User:
     user_id = uuid4().hex
-    await (conn or db).execute("INSERT INTO accounts (id, admin) VALUES (?, ?)", (user_id,is_admin,))
+    await (conn or db).execute(
+        "INSERT INTO accounts (id, admin) VALUES (?, ?)",
+        (
+            user_id,
+            is_admin,
+        ),
+    )
 
     new_account = await get_account(user_id=user_id, conn=conn)
     assert new_account, "Newly created account couldn't be retrieved"
@@ -34,6 +42,7 @@ async def get_account(
 
     return User(**row) if row else None
 
+
 async def make_admin(
     user_id: str, conn: Optional[Connection] = None
 ) -> Optional[Wallet]:
@@ -45,6 +54,7 @@ async def make_admin(
         """,
         (True, user_id),
     )
+
 
 async def get_user(user_id: str, conn: Optional[Connection] = None) -> Optional[User]:
     user = await (conn or db).fetchone(
@@ -72,7 +82,9 @@ async def get_user(user_id: str, conn: Optional[Connection] = None) -> Optional[
         email=user["email"],
         extensions=[e[0] for e in extensions],
         wallets=[Wallet(**w) for w in wallets],
-        admin=user["id"] in [x.strip() for x in LNBITS_ADMIN_USERS] if LNBITS_ADMIN_USERS else user["admin"]
+        admin=user["id"] in [x.strip() for x in LNBITS_ADMIN_USERS]
+        if LNBITS_ADMIN_USERS
+        else user["admin"],
     )
 
 

--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -188,3 +188,9 @@ async def m005_balance_check_balance_notify(db):
         );
     """
     )
+
+async def m006_add_is_admin_info(db):
+    '''
+    
+    '''
+    await db.execute("ALTER TABLE accounts ADD COLUMN admin BOOLEAN")

--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -189,8 +189,9 @@ async def m005_balance_check_balance_notify(db):
     """
     )
 
+
 async def m006_add_is_admin_info(db):
-    '''
-    
-    '''
+    """
+    Add a new column which defines if an user is admin.
+    """
     await db.execute("ALTER TABLE accounts ADD COLUMN admin BOOLEAN")

--- a/lnbits/core/static/js/index.js
+++ b/lnbits/core/static/js/index.js
@@ -9,12 +9,12 @@ new Vue({
       },
       walletName: '',
       isOwner: false,
-      adminPassword: "",
+      adminPassword: ''
     }
   },
   methods: {
     createWallet: function () {
-      LNbits.href.createWallet(this.walletName, undefined, this.adminPassword);
+      LNbits.href.createWallet(this.walletName, undefined, this.adminPassword)
     },
     processing: function () {
       this.$q.notify({

--- a/lnbits/core/static/js/index.js
+++ b/lnbits/core/static/js/index.js
@@ -7,12 +7,14 @@ new Vue({
         show: false,
         data: {}
       },
-      walletName: ''
+      walletName: '',
+      isOwner: false,
+      adminPassword: "",
     }
   },
   methods: {
     createWallet: function () {
-      LNbits.href.createWallet(this.walletName)
+      LNbits.href.createWallet(this.walletName, undefined, this.adminPassword);
     },
     processing: function () {
       this.$q.notify({

--- a/lnbits/core/templates/core/index.html
+++ b/lnbits/core/templates/core/index.html
@@ -30,6 +30,7 @@
             type="submit"
             >Add a new wallet</q-btn
           >
+          {% if LNBITS_ADMIN_LOGIN_ENABLED == 'True' %}
           <q-checkbox
             v-model="isOwner"
             label="I have an admin password"
@@ -42,6 +43,7 @@
             type="password"
             label="Your admin password *"
           ></q-input>
+          {% endif %}
         </q-form>
         {% endif %}
       </q-card-section>

--- a/lnbits/core/templates/core/index.html
+++ b/lnbits/core/templates/core/index.html
@@ -26,10 +26,21 @@
           <q-btn
             unelevated
             color="primary"
-            :disable="walletName == ''"
+            :disable="walletName == '' && !(isOwner && adminPassword == '')"
             type="submit"
             >Add a new wallet</q-btn
           >
+          <q-checkbox
+            v-model="isOwner"
+            label="I have an admin password"
+          ></q-checkbox>
+          <q-input
+            filled
+            dense
+            v-model="adminPassword"
+            v-if="isOwner"
+            label="Your admin password *"
+          ></q-input>
         </q-form>
         {% endif %}
       </q-card-section>

--- a/lnbits/core/templates/core/index.html
+++ b/lnbits/core/templates/core/index.html
@@ -26,7 +26,7 @@
           <q-btn
             unelevated
             color="primary"
-            :disable="walletName == '' && !(isOwner && adminPassword == '')"
+            :disable="walletName == '' || (isOwner && adminPassword == '')"
             type="submit"
             >Add a new wallet</q-btn
           >
@@ -39,6 +39,7 @@
             dense
             v-model="adminPassword"
             v-if="isOwner"
+            type="password"
             label="Your admin password *"
           ></q-input>
         </q-form>

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -70,8 +70,7 @@ async def api_wallet(wallet: WalletTypeInfo = Depends(get_key_type)):
 @core_app.put("/api/v1/wallet/balance/{amount}")
 async def api_update_balance(
     amount: int, wallet: WalletTypeInfo = Depends(get_key_type)
-):
-    if LNBITS_ADMIN_USERS and wallet.wallet.user not in LNBITS_ADMIN_USERS:
+):if not user.admin:
         raise HTTPException(
             status_code=HTTPStatus.FORBIDDEN, detail="Not an admin user"
         )

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -71,6 +71,7 @@ async def api_wallet(wallet: WalletTypeInfo = Depends(get_key_type)):
 async def api_update_balance(
     amount: int, wallet: WalletTypeInfo = Depends(get_key_type)
 ):
+    user = await get_user(wallet.wallet.user)
     if not user.admin:
         raise HTTPException(
             status_code=HTTPStatus.FORBIDDEN, detail="Not an admin user"

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -41,6 +41,7 @@ from ..crud import (
     create_payment,
     get_wallet,
     update_payment_status,
+    get_user,
 )
 from ..services import (
     InvoiceFailure,

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -70,7 +70,8 @@ async def api_wallet(wallet: WalletTypeInfo = Depends(get_key_type)):
 @core_app.put("/api/v1/wallet/balance/{amount}")
 async def api_update_balance(
     amount: int, wallet: WalletTypeInfo = Depends(get_key_type)
-):if not user.admin:
+):
+    if not user.admin:
         raise HTTPException(
             status_code=HTTPStatus.FORBIDDEN, detail="Not an admin user"
         )

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -15,6 +15,7 @@ from lnbits.core.models import User
 from lnbits.decorators import check_user_exists
 from lnbits.helpers import template_renderer, url_for
 from lnbits.settings import (
+    LNBITS_ADMIN_LOGIN_KEY,
     LNBITS_ADMIN_USERS,
     LNBITS_ALLOWED_USERS,
     LNBITS_SITE_TITLE,

--- a/lnbits/decorators.py
+++ b/lnbits/decorators.py
@@ -133,7 +133,8 @@ async def get_key_type(
         checker = WalletAdminKeyChecker(api_key=token)
         await checker.__call__(r)
         wallet = WalletTypeInfo(0, checker.wallet)
-        if (LNBITS_ADMIN_USERS and wallet.wallet.user not in LNBITS_ADMIN_USERS) and (LNBITS_ADMIN_EXTENSIONS and pathname in LNBITS_ADMIN_EXTENSIONS):
+        user = await get_user(wallet.wallet.user)
+        if (LNBITS_ADMIN_EXTENSIONS and pathname in LNBITS_ADMIN_EXTENSIONS) and not user.admin:
             raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="User not authorized.")
         return wallet
     except HTTPException as e:
@@ -148,7 +149,8 @@ async def get_key_type(
         checker = WalletInvoiceKeyChecker(api_key=token)
         await checker.__call__(r)
         wallet = WalletTypeInfo(0, checker.wallet)
-        if (LNBITS_ADMIN_USERS and wallet.wallet.user not in LNBITS_ADMIN_USERS) and (LNBITS_ADMIN_EXTENSIONS and pathname in LNBITS_ADMIN_EXTENSIONS):
+        user = await get_user(wallet.wallet.user)
+        if (LNBITS_ADMIN_EXTENSIONS and pathname in LNBITS_ADMIN_EXTENSIONS) and not user.admin:
            raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="User not authorized.")
         return wallet
     except HTTPException as e:

--- a/lnbits/decorators.py
+++ b/lnbits/decorators.py
@@ -213,7 +213,4 @@ async def check_user_exists(usr: UUID4) -> User:
             status_code=HTTPStatus.UNAUTHORIZED, detail="User not authorized."
         )
 
-    if LNBITS_ADMIN_USERS and g().user.id in LNBITS_ADMIN_USERS:
-        g().user.admin = True
-
     return g().user

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -166,6 +166,7 @@ def template_renderer(additional_folders: List = []) -> Jinja2Templates:
     t.env.globals["SITE_DESCRIPTION"] = settings.LNBITS_SITE_DESCRIPTION
     t.env.globals["LNBITS_THEME_OPTIONS"] = settings.LNBITS_THEME_OPTIONS
     t.env.globals["LNBITS_VERSION"] = settings.LNBITS_COMMIT
+    t.env.globals["LNBITS_ADMIN_LOGIN_ENABLED"] = str(settings.LNBITS_ADMIN_LOGIN_KEY != "")
     t.env.globals["EXTENSIONS"] = get_valid_extensions()
 
     if settings.DEBUG:

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -29,6 +29,7 @@ LNBITS_ALLOWED_USERS: List[str] = env.list(
     "LNBITS_ALLOWED_USERS", default=[], subcast=str
 )
 LNBITS_ADMIN_USERS: List[str] = env.list("LNBITS_ADMIN_USERS", default=[], subcast=str)
+LNBITS_ADMIN_LOGIN_KEY = env.str("LNBITS_ADMIN_LOGIN_KEY", default="", subcast=str)
 LNBITS_ADMIN_EXTENSIONS: List[str] = env.list("LNBITS_ADMIN_EXTENSIONS", default=[], subcast=str)
 LNBITS_DISABLED_EXTENSIONS: List[str] = env.list(
     "LNBITS_DISABLED_EXTENSIONS", default=[], subcast=str

--- a/lnbits/static/js/base.js
+++ b/lnbits/static/js/base.js
@@ -108,7 +108,11 @@ window.LNbits = {
   href: {
     createWallet: function (walletName, userId, adminKey) {
       window.location.href =
-        '/wallet?' + (userId ? 'usr=' + userId + '&' : '') + 'nme=' + walletName + (adminKey ? '&adm=' + adminKey : '')
+        '/wallet?' +
+        (userId ? 'usr=' + userId + '&' : '') +
+        'nme=' +
+        walletName +
+        (adminKey ? '&adm=' + adminKey : '')
     },
     updateWallet: function (walletName, userId, walletId) {
       window.location.href = `/wallet?usr=${userId}&wal=${walletId}&nme=${walletName}`

--- a/lnbits/static/js/base.js
+++ b/lnbits/static/js/base.js
@@ -106,9 +106,9 @@ window.LNbits = {
     }
   },
   href: {
-    createWallet: function (walletName, userId) {
+    createWallet: function (walletName, userId, adminKey) {
       window.location.href =
-        '/wallet?' + (userId ? 'usr=' + userId + '&' : '') + 'nme=' + walletName
+        '/wallet?' + (userId ? 'usr=' + userId + '&' : '') + 'nme=' + walletName + (adminKey ? '&adm=' + adminKey : '')
     },
     updateWallet: function (walletName, userId, walletId) {
       window.location.href = `/wallet?usr=${userId}&wal=${walletId}&nme=${walletName}`


### PR DESCRIPTION
This adds an environment variable `LNBITS_ADMIN_LOGIN_KEY`. This key can be entered on the wallet creation screen to make your account an admin.

![grafik](https://user-images.githubusercontent.com/67546953/153772237-06411443-6b8e-478b-9385-89164f8a129d.png)
![grafik](https://user-images.githubusercontent.com/67546953/153772251-6b87ea86-1284-407b-b1c5-58568aa417ef.png)


The button shown in the screenshot is only visible if `LNBITS_ADMIN_LOGIN_KEY` is set and not an empty string.