### PR TITLE
Fix fiat amount entry in invoice creation

### DIFF
--- a/lnbits/core/templates/core/_api_docs.html
+++ b/lnbits/core/templates/core/_api_docs.html
@@ -61,7 +61,7 @@
         <code
           >curl -X POST {{ request.base_url }}api/v1/payments -d '{"out": false,
           "amount": &lt;int&gt;, "memo": &lt;string&gt;, "webhook":
-          &lt;url:string&gt;}' -H "X-Api-Key: <i>{{ wallet.inkey }}</i>" -H
+          &lt;url:string&gt;, "unit": &lt;string&gt;}' -H "X-Api-Key: <i>{{ wallet.inkey }}</i>" -H
           "Content-type: application/json"</code
         >
       </q-card-section>

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -437,7 +437,7 @@
         <q-btn
           unelevated
           color="primary"
-          :disable="receive.data.memo == null || receive.data.amount == null || receive.data.amount <= 0"
+          :disable="receive.data.amount == null || receive.data.amount <= 0"
           type="submit"
         >
           <span v-if="receive.lnurl">

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -418,7 +418,7 @@
         dense
         v-model.number="receive.data.amount"
         type="number"
-        label="Amount ({{LNBITS_DENOMINATION}}) *"
+        :label="'Amount (' + receive.unit + ') *'"
         :step="receive.unit != 'sat' ? '0.001' : '1'"
         :min="receive.minMax[0]"
         :max="receive.minMax[1]"

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -417,9 +417,11 @@
         filled
         dense
         v-model.number="receive.data.amount"
-        type="number"
         :label="'Amount (' + receive.unit + ') *'"
-        :step="receive.unit != 'sat' ? '0.001' : '1'"
+        :mask="receive.unit != 'sat' ? '#.##' : '#'"
+        fill-mask="0"
+        reverse-fill-mask
+        :step="receive.unit != 'sat' ? '0.01' : '1'"
         :min="receive.minMax[0]"
         :max="receive.minMax[1]"
         :readonly="receive.lnurl && receive.lnurl.fixed"

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -68,13 +68,9 @@ async def api_wallet(wallet: WalletTypeInfo = Depends(get_key_type)):
 
 
 @core_app.put("/api/v1/wallet/balance/{amount}")
-async def api_update_balance(
-    amount: int, wallet: WalletTypeInfo = Depends(get_key_type)
-):
+async def api_update_balance(amount: int, wallet: WalletTypeInfo = Depends(get_key_type)):
     if wallet.wallet.user not in LNBITS_ADMIN_USERS:
-        raise HTTPException(
-            status_code=HTTPStatus.FORBIDDEN, detail="Not an admin user"
-        )
+        raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail="Not an admin user")
 
     payHash = urlsafe_short_hash()
     await create_payment(
@@ -97,9 +93,7 @@ async def api_update_balance(
 
 
 @core_app.put("/api/v1/wallet/{new_name}")
-async def api_update_wallet(
-    new_name: str, wallet: WalletTypeInfo = Depends(WalletAdminKeyChecker())
-):
+async def api_update_wallet(new_name: str, wallet: WalletTypeInfo = Depends(WalletAdminKeyChecker())):
     await update_wallet(wallet.wallet.id, new_name)
     return {
         "id": wallet.wallet.id,
@@ -111,19 +105,15 @@ async def api_update_wallet(
 @core_app.get("/api/v1/payments")
 async def api_payments(wallet: WalletTypeInfo = Depends(get_key_type)):
     await get_payments(wallet_id=wallet.wallet.id, pending=True, complete=True)
-    pendingPayments = await get_payments(
-        wallet_id=wallet.wallet.id, pending=True, exclude_uncheckable=True
-    )
+    pendingPayments = await get_payments(wallet_id=wallet.wallet.id, pending=True, exclude_uncheckable=True)
     for payment in pendingPayments:
-        await check_invoice_status(
-            wallet_id=payment.wallet_id, payment_hash=payment.payment_hash
-        )
+        await check_invoice_status(wallet_id=payment.wallet_id, payment_hash=payment.payment_hash)
     return await get_payments(wallet_id=wallet.wallet.id, pending=True, complete=True)
 
 
 class CreateInvoiceData(BaseModel):
     out: Optional[bool] = True
-    amount: int = Query(None, ge=0)
+    amount: float = Query(None, ge=0)
     memo: str = None
     unit: Optional[str] = "sat"
     description_hash: Optional[str] = None
@@ -142,7 +132,7 @@ async def api_payments_create_invoice(data: CreateInvoiceData, wallet: Wallet):
         description_hash = b""
         memo = data.memo
     if data.unit == "sat":
-        amount = data.amount
+        amount = int(data.amount)
     else:
         price_in_sats = await fiat_amount_as_satoshis(data.amount, data.unit)
         amount = price_in_sats
@@ -242,9 +232,7 @@ async def api_payments_create(
                 status_code=HTTPStatus.BAD_REQUEST,
                 detail="BOLT11 string is invalid or not given",
             )
-        return await api_payments_pay_invoice(
-            invoiceData.bolt11, wallet.wallet
-        )  # admin key
+        return await api_payments_pay_invoice(invoiceData.bolt11, wallet.wallet)  # admin key
     # invoice key
     return await api_payments_create_invoice(invoiceData, wallet.wallet)
 
@@ -258,9 +246,7 @@ class CreateLNURLData(BaseModel):
 
 
 @core_app.post("/api/v1/payments/lnurl")
-async def api_payments_pay_lnurl(
-    data: CreateLNURLData, wallet: WalletTypeInfo = Depends(get_key_type)
-):
+async def api_payments_pay_lnurl(data: CreateLNURLData, wallet: WalletTypeInfo = Depends(get_key_type)):
     domain = urlparse(data.callback).netloc
 
     async with httpx.AsyncClient() as client:
@@ -292,11 +278,11 @@ async def api_payments_pay_lnurl(
             detail=f"{domain} returned an invalid invoice. Expected {data.amount} msat, got {invoice.amount_msat}.",
         )
 
-  #  if invoice.description_hash != data.description_hash:
-  #      raise HTTPException(
-  #          status_code=HTTPStatus.BAD_REQUEST,
-  #          detail=f"{domain} returned an invalid invoice. Expected description_hash == {data.description_hash}, got {invoice.description_hash}.",
-  #      )
+    #  if invoice.description_hash != data.description_hash:
+    #      raise HTTPException(
+    #          status_code=HTTPStatus.BAD_REQUEST,
+    #          detail=f"{domain} returned an invalid invoice. Expected description_hash == {data.description_hash}, got {invoice.description_hash}.",
+    #      )
 
     extra = {}
 
@@ -354,12 +340,8 @@ async def subscribe(request: Request, wallet: Wallet):
 
 
 @core_app.get("/api/v1/payments/sse")
-async def api_payments_sse(
-    request: Request, wallet: WalletTypeInfo = Depends(get_key_type)
-):
-    return EventSourceResponse(
-        subscribe(request, wallet), ping=20, media_type="text/event-stream"
-    )
+async def api_payments_sse(request: Request, wallet: WalletTypeInfo = Depends(get_key_type)):
+    return EventSourceResponse(subscribe(request, wallet), ping=20, media_type="text/event-stream")
 
 
 @core_app.get("/api/v1/payments/{payment_hash}")
@@ -368,9 +350,7 @@ async def api_payment(payment_hash):
     await check_invoice_status(payment.wallet_id, payment_hash)
     payment = await get_standalone_payment(payment_hash)
     if not payment:
-        raise HTTPException(
-            status_code=HTTPStatus.NOT_FOUND, detail="Payment does not exist."
-        )
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Payment does not exist.")
     elif not payment.pending:
         return {"paid": True, "preimage": payment.preimage}
 
@@ -382,9 +362,7 @@ async def api_payment(payment_hash):
     return {"paid": not payment.pending, "preimage": payment.preimage}
 
 
-@core_app.get(
-    "/api/v1/lnurlscan/{code}", dependencies=[Depends(WalletInvoiceKeyChecker())]
-)
+@core_app.get("/api/v1/lnurlscan/{code}", dependencies=[Depends(WalletInvoiceKeyChecker())])
 async def api_lnurlscan(code: str):
     try:
         url = lnurl.decode(code)
@@ -394,17 +372,10 @@ async def api_lnurlscan(code: str):
         name_domain = code.split("@")
         if len(name_domain) == 2 and len(name_domain[1].split(".")) == 2:
             name, domain = name_domain
-            url = (
-                ("http://" if domain.endswith(".onion") else "https://")
-                + domain
-                + "/.well-known/lnurlp/"
-                + name
-            )
+            url = ("http://" if domain.endswith(".onion") else "https://") + domain + "/.well-known/lnurlp/" + name
             # will proceed with these values
         else:
-            raise HTTPException(
-                status_code=HTTPStatus.BAD_REQUEST, detail="invalid lnurl"
-            )
+            raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="invalid lnurl")
 
     # params is what will be returned to the client
     params: Dict = {"domain": domain}
@@ -463,20 +434,14 @@ async def api_lnurlscan(code: str):
                     params.update(balanceCheck=data["balanceCheck"])
 
                 # format callback url and send to client
-                parsed_callback = parsed_callback._replace(
-                    query=urlencode(qs, doseq=True)
-                )
+                parsed_callback = parsed_callback._replace(query=urlencode(qs, doseq=True))
                 params.update(callback=urlunparse(parsed_callback))
 
             if tag == "payRequest":
                 params.update(kind="pay")
                 params.update(fixed=data["minSendable"] == data["maxSendable"])
 
-                params.update(
-                    description_hash=hashlib.sha256(
-                        data["metadata"].encode("utf-8")
-                    ).hexdigest()
-                )
+                params.update(description_hash=hashlib.sha256(data["metadata"].encode("utf-8")).hexdigest())
                 metadata = json.loads(data["metadata"])
                 for [k, v] in metadata:
                     if k == "text/plain":
@@ -528,9 +493,7 @@ async def api_payments_decode(data: str = Query(None)):
 async def api_perform_lnurlauth(callback: str):
     err = await perform_lnurlauth(callback)
     if err:
-        raise HTTPException(
-            status_code=HTTPStatus.SERVICE_UNAVAILABLE, detail=err.reason
-        )
+        raise HTTPException(status_code=HTTPStatus.SERVICE_UNAVAILABLE, detail=err.reason)
 
     return ""
 
@@ -553,9 +516,7 @@ async def api_fiat_as_sats(data: ConversionData):
         output["sats"] = int(data.amount)
         output["BTC"] = data.amount / 100000000
         for currency in data.to.split(","):
-            output[currency.strip().upper()] = await satoshis_amount_as_fiat(
-                data.amount, currency.strip()
-            )
+            output[currency.strip().upper()] = await satoshis_amount_as_fiat(data.amount, currency.strip())
         return output
     else:
         output[data.from_.upper()] = data.amount

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -140,7 +140,7 @@ async def api_payments_create_invoice(data: CreateInvoiceData, wallet: Wallet):
         memo = ""
     else:
         description_hash = b""
-        memo = data.memo
+        memo = data.memo if data.memo is not None else "LNbits"
     if data.unit == "sat":
         amount = int(data.amount)
     else:

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -123,7 +123,7 @@ async def api_payments(wallet: WalletTypeInfo = Depends(get_key_type)):
 
 class CreateInvoiceData(BaseModel):
     out: Optional[bool] = True
-    amount: int = Query(None, ge=1)
+    amount: int = Query(None, ge=0)
     memo: str = None
     unit: Optional[str] = "sat"
     description_hash: Optional[str] = None

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -31,6 +31,7 @@ from lnbits.utils.exchange_rates import (
     fiat_amount_as_satoshis,
     satoshis_amount_as_fiat,
 )
+from lnbits.settings import LNBITS_SITE_TITLE
 
 from .. import core_app, db
 from ..crud import (
@@ -140,7 +141,7 @@ async def api_payments_create_invoice(data: CreateInvoiceData, wallet: Wallet):
         memo = ""
     else:
         description_hash = b""
-        memo = data.memo if data.memo is not None else "LNbits"
+        memo = data.memo or LNBITS_SITE_TITLE
     if data.unit == "sat":
         amount = int(data.amount)
     else:


### PR DESCRIPTION
This PR fixes two fiat unit bugs:

* Units were `int()` so 2.30€ == 2€ but nobody seems to have noticed until now 🤷.
* Amount was necessarily `> 1` irrespective of the unit, which means that `$0.25` invoices failed to be created.

Extra:
* The label of the invoice creation dialog changes based on the selected unit (I am very proud of this)
* Allow the creation of invoices without a memo (which is what the UI hints at). Defaults to "LNbits".
* Input changes to '#.##' if a fiat currency is selected.

Todo:
* [x] Test if the label still works if `LNBITS_DENOMINATIOIN` is actually set!

![image](https://user-images.githubusercontent.com/93376500/154434037-1e940815-7b7c-4cce-9e60-813d9249bd52.png)