### PR TITLE
Delete expired invoices after one pending check

### DIFF
--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -60,6 +60,7 @@ def register_invoice_listener(send_chan: asyncio.Queue):
 
 
 async def webhook_handler():
+    handler = getattr(WALLET, "webhook_listener", None)
     if handler:
         return await handler()
     raise HTTPException(status_code=HTTPStatus.NO_CONTENT)
@@ -74,7 +75,6 @@ async def internal_invoice_listener():
         asyncio.create_task(invoice_callback_dispatcher(checking_id))
 
 
-            handler = getattr(WALLET, "webhook_listener", None)
 async def invoice_listener():
     async for checking_id in WALLET.paid_invoices_stream():
         print("> got a payment notification", checking_id)
@@ -95,9 +95,8 @@ async def check_pending_payments():
             exclude_uncheckable=True,
         ):
             await payment.check_pending()
-            
-        await delete_expired_invoices()
 
+        await delete_expired_invoices()
         # after the first check we will only check outgoing, not incoming
         # that will be handled by the global invoice listeners, hopefully
         incoming = False

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -60,7 +60,6 @@ def register_invoice_listener(send_chan: asyncio.Queue):
 
 
 async def webhook_handler():
-    handler = getattr(WALLET, "webhook_listener", None)
     if handler:
         return await handler()
     raise HTTPException(status_code=HTTPStatus.NO_CONTENT)
@@ -75,6 +74,7 @@ async def internal_invoice_listener():
         asyncio.create_task(invoice_callback_dispatcher(checking_id))
 
 
+            handler = getattr(WALLET, "webhook_listener", None)
 async def invoice_listener():
     async for checking_id in WALLET.paid_invoices_stream():
         print("> got a payment notification", checking_id)
@@ -82,8 +82,6 @@ async def invoice_listener():
 
 
 async def check_pending_payments():
-    await delete_expired_invoices()
-
     outgoing = True
     incoming = True
 
@@ -97,6 +95,8 @@ async def check_pending_payments():
             exclude_uncheckable=True,
         ):
             await payment.check_pending()
+            
+        await delete_expired_invoices()
 
         # after the first check we will only check outgoing, not incoming
         # that will be handled by the global invoice listeners, hopefully

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -96,7 +96,9 @@ async def check_pending_payments():
         ):
             await payment.check_pending()
 
-        await delete_expired_invoices()
+        # we delete expired invoices once upon the first pending check
+        if incoming:
+            await delete_expired_invoices()
         # after the first check we will only check outgoing, not incoming
         # that will be handled by the global invoice listeners, hopefully
         incoming = False


### PR DESCRIPTION
PR fixes two bugs:

* Check for expired invoices regularly, instead of only upon startup.
* Expired invoices should only be deleted after one pending check. The backend could have been offline for a very long time and expired invoices could have been paid in the mean time. 