### PR TITLE
Retry backend connection on startup

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -84,8 +84,7 @@ def create_app(config_object="lnbits.settings") -> FastAPI:
 def check_funding_source(app: FastAPI) -> None:
     @app.on_event("startup")
     async def check_wallet_status():
-        success = False
-        while not success:
+        while True:
             error_message, balance = await WALLET.status()
             if not error_message:
                 break

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -84,18 +84,20 @@ def create_app(config_object="lnbits.settings") -> FastAPI:
 def check_funding_source(app: FastAPI) -> None:
     @app.on_event("startup")
     async def check_wallet_status():
-        error_message, balance = await WALLET.status()
-        if error_message:
+        success = False
+        while not success:
+            error_message, balance = await WALLET.status()
+            if not error_message:
+                break
             warnings.warn(
                 f"  × The backend for {WALLET.__class__.__name__} isn't working properly: '{error_message}'",
                 RuntimeWarning,
             )
-
-            sys.exit(4)
-        else:
-            print(
-                f"  ✔️ {WALLET.__class__.__name__} seems to be connected and with a balance of {balance} msat."
-            )
+            print("Retrying connection to backend in 5 seconds...")
+            await asyncio.sleep(5)
+        print(
+            f"  ✔️ {WALLET.__class__.__name__} seems to be connected and with a balance of {balance} msat."
+        )
 
 
 def register_routes(app: FastAPI) -> None:


### PR DESCRIPTION
Retry the connection to the backend every 5 seconds if the connection fails. Before, we used to `sys.exit(4)`.

This is useful for Umbrel users who don't use a proper systemd startup chain like a normal person, which means that lnbits doesn't know when lnd is actually ready (and unlocked) to receive connections. 