### PR TITLE
Add support for the system's cert chain in LndRestWallet

### DIFF
--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -43,7 +43,7 @@ class LndRestWallet(Wallet):
         self.macaroon = load_macaroon(macaroon)
         
         self.auth = {"Grpc-Metadata-macaroon": self.macaroon}
-        self.cert = getenv("LND_REST_CERT")
+        self.cert = getenv("LND_REST_CERT", True)
 
     async def status(self) -> StatusResponse:
         try:


### PR DESCRIPTION
This PR adds a fallback to the `LND_REST_CERT` variable. If the user is using the `LndRestWallet` provider but does not supply the `LND_REST_CERT` variable, then LNBits will fallback to using the system's root certificate chain to validate the node's certificate.