### PR TITLE
wip: Implements LUD22 from LNURL spec

### DIFF
--- a/lnbits/extensions/lnurlp/templates/lnurlp/index.html
+++ b/lnbits/extensions/lnurlp/templates/lnurlp/index.html
@@ -275,8 +275,8 @@
           fiatRates[qrCodeDialog.data.currency] + ' sat' : 'Loading...' }}<br
         /></span>
         <strong>Accepts comments:</strong> {{ qrCodeDialog.data.comments }}<br />
-        <strong>Dispatches webhook to:</strong> {{ qrCodeDialog.data.webhook
-        }}<br />
+        <strong>Dispatches LUD22 webhook to:</strong> {{
+        qrCodeDialog.data.webhook }}<br />
         <strong>On success:</strong> {{ qrCodeDialog.data.success }}<br />
       </p>
       {% endraw %}


### PR DESCRIPTION
The extension LNURLpay has capacity to set a webhook, this pr just formalises by changing the workflow to LUD22 https://github.com/fiatjaf/lnurl-rfc/pull/122/files

A webhook can also be passed and honoured by lnbits wallet if an lnurlpay is paid by the wallet