### PR TITLE
fail early if LNBITS_DATA_FOLDER missing

### DIFF
--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -130,9 +130,15 @@ class Database(Compat):
                 )
             )
         else:
-            self.path = os.path.join(LNBITS_DATA_FOLDER, f"{self.name}.sqlite3")
-            database_uri = f"sqlite:///{self.path}"
-            self.type = SQLITE
+            if os.path.isdir(LNBITS_DATA_FOLDER):
+                self.path = os.path.join(LNBITS_DATA_FOLDER, f"{self.name}.sqlite3")
+                database_uri = f"sqlite:///{self.path}"
+                self.type = SQLITE
+            else:
+                raise NotADirectoryError(
+                    f"LNBITS_DATA_FOLDER named {LNBITS_DATA_FOLDER} was not created"
+                    f" - please 'mkdir {LNBITS_DATA_FOLDER}' and try again"
+                )
 
         self.schema = self.name
         if self.name.startswith("ext_"):


### PR DESCRIPTION
Ran into the issue of not having a `LNBITS_DATA_FOLDER` (default is `data`) set once too often when setting up LNBits - Maybe helpful for others too.

Without it the guard clause failure will happen later when trying to open the database files:

```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file
```

Keep up the great work!