### PR TITLE
add "IRT" currency to TPos extention

### DIFF
--- a/lnbits/extensions/tpos/templates/tpos/index.html
+++ b/lnbits/extensions/tpos/templates/tpos/index.html
@@ -222,6 +222,7 @@
           'INR',
           'IQD',
           'IRR',
+          'IRT'
           'ISK',
           'JEP',
           'JMD',


### PR DESCRIPTION
hi,
two days ago, @lilcheti added IRT to "exchange_rates.py". I noticed that the "TPos" extension does not have IRT currency in its list. So I added it.