### PR TITLE
Updating references from `c-lightning` to `Core Lightning`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN pip install wheel
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt
 
-# Install c-lightning specific deps
+# Install Core Lightning specific deps
 RUN pip install pylightning
 
 # Install LND specific deps

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ LNbits is a very simple Python server that sits on top of any funding source, an
 * Fallback wallet for the LNURL scheme
 * Instant wallet for LN demonstrations
 
-LNbits can run on top of any lightning-network funding source, currently there is support for LND, c-lightning, Spark, LNpay, OpenNode, lntxbot, with more being added regularly.
+LNbits can run on top of any lightning-network funding source, currently there is support for LND, Core Lightning, Spark, LNpay, OpenNode, lntxbot, with more being added regularly.
 
 See [lnbits.org](https://lnbits.org) for more detailed documentation.
 

--- a/docs/guide/wallets.md
+++ b/docs/guide/wallets.md
@@ -9,7 +9,7 @@ Backend wallets
 ===============
 
 LNbits can run on top of many lightning-network funding sources. Currently there is support for
-CLightning, LND, LNbits, LNPay, lntxbot and OpenNode, with more being added regularily.
+Core Lightning, LND, LNbits, LNPay, lntxbot and OpenNode, with more being added regularily.
 
 A backend wallet can be configured using the following LNbits environment variables:
 
@@ -17,12 +17,12 @@ A backend wallet can be configured using the following LNbits environment variab
 ### CLightning
 
 Using this wallet requires the installation of the `pylightning` Python package.
-If you want to use LNURLp you should use SparkWallet because of an issue with description_hash and CLightning.
+If you want to use LNURLp you should use SparkWallet because of an issue with description_hash and Core Lightning.
 
 - `LNBITS_BACKEND_WALLET_CLASS`: **CLightningWallet**
 - `CLIGHTNING_RPC`: /file/path/lightning-rpc
 
-### Spark (c-lightning)
+### Spark (Core Lightning)
 
 - `LNBITS_BACKEND_WALLET_CLASS`: **SparkWallet**
 - `SPARK_URL`: http://10.147.17.230:9737/rpc

--- a/lnbits/core/templates/core/index.html
+++ b/lnbits/core/templates/core/index.html
@@ -43,7 +43,7 @@
           <p>
             Easy to set up and lightweight, LNbits can run on any
             lightning-network funding source, currently supporting LND,
-            c-lightning, OpenNode, lntxbot, LNPay and even LNbits itself!
+            Core Lightning, OpenNode, lntxbot, LNPay and even LNbits itself!
           </p>
           <p>
             You can run LNbits for yourself, or easily offer a custodian


### PR DESCRIPTION
@blockstream has re-named `c-lightning` to `Core Lightning`: See https://blog.blockstream.com/en-c-lightning-is-now-core-lightning/

Quick PR to update the website reference to c-lightning, along with some comments and docs.