### PR TITLE
Core: add internal flag for invoice creation to use FakeWallet

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -14,7 +14,7 @@ from lnbits import bolt11
 from lnbits.db import Connection
 from lnbits.helpers import url_for, urlsafe_short_hash
 from lnbits.requestvars import g
-from lnbits.settings import WALLET, FAKE_WALLET
+from lnbits.settings import FAKE_WALLET, WALLET
 from lnbits.wallets.base import PaymentResponse, PaymentStatus
 
 from . import db

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -14,7 +14,7 @@ from lnbits import bolt11
 from lnbits.db import Connection
 from lnbits.helpers import url_for, urlsafe_short_hash
 from lnbits.requestvars import g
-from lnbits.settings import WALLET
+from lnbits.settings import WALLET, FAKE_WALLET
 from lnbits.wallets.base import PaymentResponse, PaymentStatus
 
 from . import db
@@ -49,11 +49,15 @@ async def create_invoice(
     description_hash: Optional[bytes] = None,
     extra: Optional[Dict] = None,
     webhook: Optional[str] = None,
+    internal: Optional[bool] = False,
     conn: Optional[Connection] = None,
 ) -> Tuple[str, str]:
     invoice_memo = None if description_hash else memo
 
-    ok, checking_id, payment_request, error_message = await WALLET.create_invoice(
+    # use the fake wallet if the invoice is for internal use only
+    wallet = FAKE_WALLET if internal else WALLET
+
+    ok, checking_id, payment_request, error_message = await wallet.create_invoice(
         amount=amount, memo=invoice_memo, description_hash=description_hash
     )
     if not ok:

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -61,7 +61,7 @@ async def create_invoice(
         amount=amount, memo=invoice_memo, description_hash=description_hash
     )
     if not ok:
-        raise InvoiceFailure(error_message or "Unexpected backend error.")
+        raise InvoiceFailure(error_message or "unexpected backend error.")
 
     invoice = bolt11.decode(payment_request)
 

--- a/lnbits/core/templates/core/_api_docs.html
+++ b/lnbits/core/templates/core/_api_docs.html
@@ -1,10 +1,20 @@
-<q-expansion-item group="extras" icon="swap_vertical_circle" label="API info" :content-inset-level="0.5">
+<q-expansion-item
+  group="extras"
+  icon="swap_vertical_circle"
+  label="API info"
+  :content-inset-level="0.5"
+>
   <q-card-section>
     <strong>Wallet ID: </strong><em>{{ wallet.id }}</em><br />
     <strong>Admin key: </strong><em>{{ wallet.adminkey }}</em><br />
     <strong>Invoice/read key: </strong><em>{{ wallet.inkey }}</em>
   </q-card-section>
-  <q-expansion-item group="api" dense expand-separator label="Get wallet details">
+  <q-expansion-item
+    group="api"
+    dense
+    expand-separator
+    label="Get wallet details"
+  >
     <q-card>
       <q-card-section>
         <code><span class="text-light-green">GET</span> /api/v1/wallet</code>
@@ -13,37 +23,58 @@
         <h5 class="text-caption q-mt-sm q-mb-none">
           Returns 200 OK (application/json)
         </h5>
-        <code>{"id": &lt;string&gt;, "name": &lt;string&gt;, "balance":
-          &lt;int&gt;}</code>
+        <code
+          >{"id": &lt;string&gt;, "name": &lt;string&gt;, "balance":
+          &lt;int&gt;}</code
+        >
         <h5 class="text-caption q-mt-sm q-mb-none">Curl example</h5>
-        <code>curl {{ request.base_url }}api/v1/wallet -H "X-Api-Key:
-          <i>{{ wallet.inkey }}</i>"</code>
+        <code
+          >curl {{ request.base_url }}api/v1/wallet -H "X-Api-Key:
+          <i>{{ wallet.inkey }}</i>"</code
+        >
       </q-card-section>
     </q-card>
   </q-expansion-item>
-  <q-expansion-item group="api" dense expand-separator label="Create an invoice (incoming)">
+  <q-expansion-item
+    group="api"
+    dense
+    expand-separator
+    label="Create an invoice (incoming)"
+  >
     <q-card>
       <q-card-section>
         <code><span class="text-light-green">POST</span> /api/v1/payments</code>
         <h5 class="text-caption q-mt-sm q-mb-none">Headers</h5>
         <code>{"X-Api-Key": "<i>{{ wallet.inkey }}</i>"}</code><br />
         <h5 class="text-caption q-mt-sm q-mb-none">Body (application/json)</h5>
-        <code>{"out": false, "amount": &lt;int&gt;, "memo": &lt;string&gt;, "unit":
-          &lt;string&gt;, "webhook": &lt;url:string&gt;, "internal": &lt;bool&gt;}</code>
+        <code
+          >{"out": false, "amount": &lt;int&gt;, "memo": &lt;string&gt;, "unit":
+          &lt;string&gt;, "webhook": &lt;url:string&gt;, "internal":
+          &lt;bool&gt;}</code
+        >
         <h5 class="text-caption q-mt-sm q-mb-none">
           Returns 201 CREATED (application/json)
         </h5>
-        <code>{"payment_hash": &lt;string&gt;, "payment_request":
-          &lt;string&gt;}</code>
+        <code
+          >{"payment_hash": &lt;string&gt;, "payment_request":
+          &lt;string&gt;}</code
+        >
         <h5 class="text-caption q-mt-sm q-mb-none">Curl example</h5>
-        <code>curl -X POST {{ request.base_url }}api/v1/payments -d '{"out": false,
+        <code
+          >curl -X POST {{ request.base_url }}api/v1/payments -d '{"out": false,
           "amount": &lt;int&gt;, "memo": &lt;string&gt;, "webhook":
           &lt;url:string&gt;, "unit": &lt;string&gt;}' -H "X-Api-Key:
-          <i>{{ wallet.inkey }}</i>" -H "Content-type: application/json"</code>
+          <i>{{ wallet.inkey }}</i>" -H "Content-type: application/json"</code
+        >
       </q-card-section>
     </q-card>
   </q-expansion-item>
-  <q-expansion-item group="api" dense expand-separator label="Pay an invoice (outgoing)">
+  <q-expansion-item
+    group="api"
+    dense
+    expand-separator
+    label="Pay an invoice (outgoing)"
+  >
     <q-card>
       <q-card-section>
         <code><span class="text-light-green">POST</span> /api/v1/payments</code>
@@ -56,19 +87,28 @@
         </h5>
         <code>{"payment_hash": &lt;string&gt;}</code>
         <h5 class="text-caption q-mt-sm q-mb-none">Curl example</h5>
-        <code>curl -X POST {{ request.base_url }}api/v1/payments -d '{"out": true,
+        <code
+          >curl -X POST {{ request.base_url }}api/v1/payments -d '{"out": true,
           "bolt11": &lt;string&gt;}' -H "X-Api-Key:
           <i>{{ wallet.adminkey }}"</i> -H "Content-type:
-          application/json"</code>
+          application/json"</code
+        >
       </q-card-section>
     </q-card>
   </q-expansion-item>
 
-  <q-expansion-item group="api" dense expand-separator label="Decode an invoice">
+  <q-expansion-item
+    group="api"
+    dense
+    expand-separator
+    label="Decode an invoice"
+  >
     <q-card>
       <q-card-section>
-        <code><span class="text-light-green">POST</span>
-          /api/v1/payments/decode</code>
+        <code
+          ><span class="text-light-green">POST</span>
+          /api/v1/payments/decode</code
+        >
         <h5 class="text-caption q-mt-sm q-mb-none">Headers</h5>
         <code>{"X-Api-Key": "<i>{{ wallet.inkey }}</i>"}</code><br />
         <h5 class="text-caption q-mt-sm q-mb-none">Body (application/json)</h5>
@@ -77,17 +117,27 @@
           Returns 200 (application/json)
         </h5>
         <h5 class="text-caption q-mt-sm q-mb-none">Curl example</h5>
-        <code>curl -X POST {{ request.base_url }}api/v1/payments/decode -d
+        <code
+          >curl -X POST {{ request.base_url }}api/v1/payments/decode -d
           '{"data": &lt;bolt11/lnurl, string&gt;}' -H "X-Api-Key:
-          <i>{{ wallet.inkey }}</i>" -H "Content-type: application/json"</code>
+          <i>{{ wallet.inkey }}</i>" -H "Content-type: application/json"</code
+        >
       </q-card-section>
     </q-card>
   </q-expansion-item>
-  <q-expansion-item group="api" dense expand-separator label="Check an invoice (incoming or outgoing)" class="q-pb-md">
+  <q-expansion-item
+    group="api"
+    dense
+    expand-separator
+    label="Check an invoice (incoming or outgoing)"
+    class="q-pb-md"
+  >
     <q-card>
       <q-card-section>
-        <code><span class="text-light-blue">GET</span>
-          /api/v1/payments/&lt;payment_hash&gt;</code>
+        <code
+          ><span class="text-light-blue">GET</span>
+          /api/v1/payments/&lt;payment_hash&gt;</code
+        >
         <h5 class="text-caption q-mt-sm q-mb-none">Headers</h5>
         <code>{"X-Api-Key": "{{ wallet.inkey }}"}</code>
         <h5 class="text-caption q-mt-sm q-mb-none">
@@ -95,9 +145,11 @@
         </h5>
         <code>{"paid": &lt;bool&gt;}</code>
         <h5 class="text-caption q-mt-sm q-mb-none">Curl example</h5>
-        <code>curl -X GET {{ request.base_url
+        <code
+          >curl -X GET {{ request.base_url
           }}api/v1/payments/&lt;payment_hash&gt; -H "X-Api-Key:
-          <i>{{ wallet.inkey }}"</i> -H "Content-type: application/json"</code>
+          <i>{{ wallet.inkey }}"</i> -H "Content-type: application/json"</code
+        >
       </q-card-section>
     </q-card>
   </q-expansion-item>

--- a/lnbits/core/templates/core/_api_docs.html
+++ b/lnbits/core/templates/core/_api_docs.html
@@ -1,20 +1,10 @@
-<q-expansion-item
-  group="extras"
-  icon="swap_vertical_circle"
-  label="API info"
-  :content-inset-level="0.5"
->
+<q-expansion-item group="extras" icon="swap_vertical_circle" label="API info" :content-inset-level="0.5">
   <q-card-section>
     <strong>Wallet ID: </strong><em>{{ wallet.id }}</em><br />
     <strong>Admin key: </strong><em>{{ wallet.adminkey }}</em><br />
     <strong>Invoice/read key: </strong><em>{{ wallet.inkey }}</em>
   </q-card-section>
-  <q-expansion-item
-    group="api"
-    dense
-    expand-separator
-    label="Get wallet details"
-  >
+  <q-expansion-item group="api" dense expand-separator label="Get wallet details">
     <q-card>
       <q-card-section>
         <code><span class="text-light-green">GET</span> /api/v1/wallet</code>
@@ -23,57 +13,37 @@
         <h5 class="text-caption q-mt-sm q-mb-none">
           Returns 200 OK (application/json)
         </h5>
-        <code
-          >{"id": &lt;string&gt;, "name": &lt;string&gt;, "balance":
-          &lt;int&gt;}</code
-        >
+        <code>{"id": &lt;string&gt;, "name": &lt;string&gt;, "balance":
+          &lt;int&gt;}</code>
         <h5 class="text-caption q-mt-sm q-mb-none">Curl example</h5>
-        <code
-          >curl {{ request.base_url }}api/v1/wallet -H "X-Api-Key:
-          <i>{{ wallet.inkey }}</i>"</code
-        >
+        <code>curl {{ request.base_url }}api/v1/wallet -H "X-Api-Key:
+          <i>{{ wallet.inkey }}</i>"</code>
       </q-card-section>
     </q-card>
   </q-expansion-item>
-  <q-expansion-item
-    group="api"
-    dense
-    expand-separator
-    label="Create an invoice (incoming)"
-  >
+  <q-expansion-item group="api" dense expand-separator label="Create an invoice (incoming)">
     <q-card>
       <q-card-section>
         <code><span class="text-light-green">POST</span> /api/v1/payments</code>
         <h5 class="text-caption q-mt-sm q-mb-none">Headers</h5>
         <code>{"X-Api-Key": "<i>{{ wallet.inkey }}</i>"}</code><br />
         <h5 class="text-caption q-mt-sm q-mb-none">Body (application/json)</h5>
-        <code
-          >{"out": false, "amount": &lt;int&gt;, "memo": &lt;string&gt;, "unit":
-          &lt;string&gt;, "webhook": &lt;url:string&gt;}</code
-        >
+        <code>{"out": false, "amount": &lt;int&gt;, "memo": &lt;string&gt;, "unit":
+          &lt;string&gt;, "webhook": &lt;url:string&gt;, "internal": &lt;bool&gt;}</code>
         <h5 class="text-caption q-mt-sm q-mb-none">
           Returns 201 CREATED (application/json)
         </h5>
-        <code
-          >{"payment_hash": &lt;string&gt;, "payment_request":
-          &lt;string&gt;}</code
-        >
+        <code>{"payment_hash": &lt;string&gt;, "payment_request":
+          &lt;string&gt;}</code>
         <h5 class="text-caption q-mt-sm q-mb-none">Curl example</h5>
-        <code
-          >curl -X POST {{ request.base_url }}api/v1/payments -d '{"out": false,
+        <code>curl -X POST {{ request.base_url }}api/v1/payments -d '{"out": false,
           "amount": &lt;int&gt;, "memo": &lt;string&gt;, "webhook":
           &lt;url:string&gt;, "unit": &lt;string&gt;}' -H "X-Api-Key:
-          <i>{{ wallet.inkey }}</i>" -H "Content-type: application/json"</code
-        >
+          <i>{{ wallet.inkey }}</i>" -H "Content-type: application/json"</code>
       </q-card-section>
     </q-card>
   </q-expansion-item>
-  <q-expansion-item
-    group="api"
-    dense
-    expand-separator
-    label="Pay an invoice (outgoing)"
-  >
+  <q-expansion-item group="api" dense expand-separator label="Pay an invoice (outgoing)">
     <q-card>
       <q-card-section>
         <code><span class="text-light-green">POST</span> /api/v1/payments</code>
@@ -86,28 +56,19 @@
         </h5>
         <code>{"payment_hash": &lt;string&gt;}</code>
         <h5 class="text-caption q-mt-sm q-mb-none">Curl example</h5>
-        <code
-          >curl -X POST {{ request.base_url }}api/v1/payments -d '{"out": true,
+        <code>curl -X POST {{ request.base_url }}api/v1/payments -d '{"out": true,
           "bolt11": &lt;string&gt;}' -H "X-Api-Key:
           <i>{{ wallet.adminkey }}"</i> -H "Content-type:
-          application/json"</code
-        >
+          application/json"</code>
       </q-card-section>
     </q-card>
   </q-expansion-item>
 
-  <q-expansion-item
-    group="api"
-    dense
-    expand-separator
-    label="Decode an invoice"
-  >
+  <q-expansion-item group="api" dense expand-separator label="Decode an invoice">
     <q-card>
       <q-card-section>
-        <code
-          ><span class="text-light-green">POST</span>
-          /api/v1/payments/decode</code
-        >
+        <code><span class="text-light-green">POST</span>
+          /api/v1/payments/decode</code>
         <h5 class="text-caption q-mt-sm q-mb-none">Headers</h5>
         <code>{"X-Api-Key": "<i>{{ wallet.inkey }}</i>"}</code><br />
         <h5 class="text-caption q-mt-sm q-mb-none">Body (application/json)</h5>
@@ -116,27 +77,17 @@
           Returns 200 (application/json)
         </h5>
         <h5 class="text-caption q-mt-sm q-mb-none">Curl example</h5>
-        <code
-          >curl -X POST {{ request.base_url }}api/v1/payments/decode -d
+        <code>curl -X POST {{ request.base_url }}api/v1/payments/decode -d
           '{"data": &lt;bolt11/lnurl, string&gt;}' -H "X-Api-Key:
-          <i>{{ wallet.inkey }}</i>" -H "Content-type: application/json"</code
-        >
+          <i>{{ wallet.inkey }}</i>" -H "Content-type: application/json"</code>
       </q-card-section>
     </q-card>
   </q-expansion-item>
-  <q-expansion-item
-    group="api"
-    dense
-    expand-separator
-    label="Check an invoice (incoming or outgoing)"
-    class="q-pb-md"
-  >
+  <q-expansion-item group="api" dense expand-separator label="Check an invoice (incoming or outgoing)" class="q-pb-md">
     <q-card>
       <q-card-section>
-        <code
-          ><span class="text-light-blue">GET</span>
-          /api/v1/payments/&lt;payment_hash&gt;</code
-        >
+        <code><span class="text-light-blue">GET</span>
+          /api/v1/payments/&lt;payment_hash&gt;</code>
         <h5 class="text-caption q-mt-sm q-mb-none">Headers</h5>
         <code>{"X-Api-Key": "{{ wallet.inkey }}"}</code>
         <h5 class="text-caption q-mt-sm q-mb-none">
@@ -144,11 +95,9 @@
         </h5>
         <code>{"paid": &lt;bool&gt;}</code>
         <h5 class="text-caption q-mt-sm q-mb-none">Curl example</h5>
-        <code
-          >curl -X GET {{ request.base_url
+        <code>curl -X GET {{ request.base_url
           }}api/v1/payments/&lt;payment_hash&gt; -H "X-Api-Key:
-          <i>{{ wallet.inkey }}"</i> -H "Content-type: application/json"</code
-        >
+          <i>{{ wallet.inkey }}"</i> -H "Content-type: application/json"</code>
       </q-card-section>
     </q-card>
   </q-expansion-item>

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -147,6 +147,7 @@ class CreateInvoiceData(BaseModel):
     lnurl_balance_check: Optional[str] = None
     extra: Optional[dict] = None
     webhook: Optional[str] = None
+    internal: Optional[bool] = False
     bolt11: Optional[str] = None
 
 
@@ -173,6 +174,7 @@ async def api_payments_create_invoice(data: CreateInvoiceData, wallet: Wallet):
                 description_hash=description_hash,
                 extra=data.extra,
                 webhook=data.webhook,
+                internal=data.internal,
                 conn=conn,
             )
         except InvoiceFailure as e:

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -51,6 +51,7 @@ LNBITS_THEME_OPTIONS: List[str] = env.list(
 LNBITS_CUSTOM_LOGO = env.str("LNBITS_CUSTOM_LOGO", default="")
 
 WALLET = wallet_class()
+FAKE_WALLET = getattr(wallets_module, "FakeWallet")()
 DEFAULT_WALLET_NAME = env.str("LNBITS_DEFAULT_WALLET_NAME", default="LNbits wallet")
 PREFER_SECURE_URLS = env.bool("LNBITS_FORCE_HTTPS", default=True)
 

--- a/lnbits/wallets/fake.py
+++ b/lnbits/wallets/fake.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from os import getenv
 from typing import AsyncGenerator, Dict, Optional
 
+from environs import Env  # type: ignore
 from loguru import logger
 
 from lnbits.helpers import urlsafe_short_hash
@@ -17,8 +18,6 @@ from .base import (
     StatusResponse,
     Wallet,
 )
-
-from environs import Env  # type: ignore
 
 env = Env()
 env.read_env()
@@ -37,6 +36,8 @@ class FakeWallet(Wallet):
         memo: Optional[str] = None,
         description_hash: Optional[bytes] = None,
     ) -> InvoiceResponse:
+        # we set a default secret since FakeWallet is used for internal=True invoices
+        # and the user might not have configured a secret yet
         secret = env.str("FAKE_WALLET_SECTRET", default="ToTheMoon1")
         data: Dict = {
             "out": False,

--- a/lnbits/wallets/fake.py
+++ b/lnbits/wallets/fake.py
@@ -18,6 +18,11 @@ from .base import (
     Wallet,
 )
 
+from environs import Env  # type: ignore
+
+env = Env()
+env.read_env()
+
 
 class FakeWallet(Wallet):
     async def status(self) -> StatusResponse:
@@ -32,7 +37,7 @@ class FakeWallet(Wallet):
         memo: Optional[str] = None,
         description_hash: Optional[bytes] = None,
     ) -> InvoiceResponse:
-        secret = getenv("FAKE_WALLET_SECRET")
+        secret = env.str("FAKE_WALLET_SECTRET", default="ToTheMoon1")
         data: Dict = {
             "out": False,
             "amount": amount,

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -25,13 +25,33 @@ async def test_create_invoice(client, inkey_headers_to):
     response = await client.post(
         "/api/v1/payments", json=data, headers=inkey_headers_to
     )
-    assert response.status_code < 300
-    assert "payment_hash" in response.json()
-    assert len(response.json()["payment_hash"]) == 64
-    assert "payment_request" in response.json()
-    assert "checking_id" in response.json()
-    assert len(response.json()["checking_id"])
-    return response.json()
+    assert response.status_code == 201
+    invoice = response.json()
+    assert "payment_hash" in invoice
+    assert len(invoice["payment_hash"]) == 64
+    assert "payment_request" in invoice
+    assert "checking_id" in invoice
+    assert len(invoice["checking_id"])
+    return invoice
+
+
+# check POST /api/v1/payments: invoice creation for internal payments only
+@pytest.mark.asyncio
+async def test_create_internal_invoice(client, inkey_headers_to):
+    data = await get_random_invoice_data()
+    data["internal"] = True
+    response = await client.post(
+        "/api/v1/payments", json=data, headers=inkey_headers_to
+    )
+    invoice = response.json()
+    assert response.status_code == 201
+    assert "payment_hash" in invoice
+    assert len(invoice["payment_hash"]) == 64
+    assert "payment_request" in invoice
+    assert "checking_id" in invoice
+    assert invoice["internal"] is True
+    assert len(invoice["checking_id"])
+    return invoice
 
 
 # check POST /api/v1/payments: make payment

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -49,7 +49,6 @@ async def test_create_internal_invoice(client, inkey_headers_to):
     assert len(invoice["payment_hash"]) == 64
     assert "payment_request" in invoice
     assert "checking_id" in invoice
-    assert invoice["internal"] is True
     assert len(invoice["checking_id"])
     return invoice
 


### PR DESCRIPTION
When using a lightning backend, every invoice is created by a backend node, even if those invoices are meant to be paid only internally (user-to-user transfer). This creates unnecessary data on the backend's end. 

@arcbtc has coded up the `FakeWalelt` which can act as a backend replacement. 

This adds a new flag `internal=True` to the `data` field of `api_payments_create_invoice()` which forces the use of `FakeWallet` even if another wallet is chosen for regular use. 

Tested.

<img width="470" alt="image" src="https://user-images.githubusercontent.com/93376500/179398353-09071305-272f-42ba-bf00-32176c62ba4d.png">