### PR TITLE
Core: fix internal webhooks

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -180,13 +180,16 @@ async def get_wallet_for_key(
 
 
 async def get_standalone_payment(
-    checking_id_or_hash: str, conn: Optional[Connection] = None
+    checking_id_or_hash: str, conn: Optional[Connection] = None, incoming: bool = False
 ) -> Optional[Payment]:
+    clause: str = "checking_id = ? OR hash = ?"
+    if incoming:
+        clause = f"({clause}) AND amount > 0"
     row = await (conn or db).fetchone(
-        """
+        f"""
         SELECT *
         FROM apipayments
-        WHERE checking_id = ? OR hash = ?
+        WHERE {clause}
         LIMIT 1
         """,
         (checking_id_or_hash, checking_id_or_hash),

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -180,7 +180,9 @@ async def get_wallet_for_key(
 
 
 async def get_standalone_payment(
-    checking_id_or_hash: str, conn: Optional[Connection] = None, incoming: bool = False
+    checking_id_or_hash: str,
+    conn: Optional[Connection] = None,
+    incoming: Optional[bool] = False,
 ) -> Optional[Payment]:
     clause: str = "checking_id = ? OR hash = ?"
     if incoming:

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -114,7 +114,7 @@ async def perform_balance_checks():
 
 
 async def invoice_callback_dispatcher(checking_id: str):
-    payment = await get_standalone_payment(checking_id)
+    payment = await get_standalone_payment(checking_id, incoming=True)
     if payment and payment.is_in:
         await payment.set_pending(False)
         for send_chan in invoice_listeners:


### PR DESCRIPTION
This PR fixes webhooks for internal payments.

The bug was reintroduced by [this PR](https://github.com/lnbits/lnbits-legend/pull/500) which reverted the fix because it probably caused problems at some other point. I've put the fix back in but now only if an optional flag `get_standalone_payment(..., internal=True)` is used. This should make sure that this change doesn't affect anything but the webhook (which uses `internal=True`).

The reason why this bug is there in the first place is mildly interesting: `get_standalone_payment` always fetched the first row in the database it finds. If two payments have the same hash (which is the case for internal payments) it is only going to fetch the outgoing payment (with negative amount). This payment however does not (and is not supposed to) fire a webhook. Therefore, there is a new optional flag now (`internal=True`) that is only used in this specific call of `get_standalone_payment`. 

Tested, works.

Fixes #639