### PR TITLE
Fix api_link_retrieve in withdraw extension

### DIFF
--- a/lnbits/extensions/withdraw/views_api.py
+++ b/lnbits/extensions/withdraw/views_api.py
@@ -60,7 +60,7 @@ async def api_link_retrieve(
         raise HTTPException(
             detail="Not your withdraw link.", status_code=HTTPStatus.FORBIDDEN
         )
-    return {**link, **{"lnurl": link.lnurl(request)}}
+    return {**{"lnurl": link.lnurl(request)}}
 
 
 @withdraw_ext.post("/api/v1/links", status_code=HTTPStatus.CREATED)


### PR DESCRIPTION
It's apparently extra in there and causing responses of HTML instead of a json like in #456