### PR TITLE
Fixed problem to exchanging IRT to BTC.

### DIFF
--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -180,6 +180,12 @@ class Provider(NamedTuple):
 
 
 exchange_rate_providers = {
+    "nobitex": Provider(
+        "Nobitex",
+        "nobitex.ir",
+        "https://api.nobitex.ir/v2/orderbook/{FROM}IRT",
+        lambda data, replacements: data["lastTradePrice"],
+    ), 
     "exir": Provider(
         "Exir",
         "exir.io",
@@ -289,8 +295,8 @@ async def get_fiat_rate_satoshis(currency: str) -> float:
     return float(100_000_000 / (await btc_price(currency)))
 
 
-async def fiat_amount_as_satoshis(amount: float, currency: str) -> int:
-    return int(amount * (await get_fiat_rate_satoshis(currency)))
+async def fiat_amount_as_satoshis(amount: float, currency: str) -> float:
+    return float(amount * (await get_fiat_rate_satoshis(currency)))
 
 
 async def satoshis_amount_as_fiat(amount: float, currency: str) -> float:

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -295,8 +295,12 @@ async def get_fiat_rate_satoshis(currency: str) -> float:
     return float(100_000_000 / (await btc_price(currency)))
 
 
-async def fiat_amount_as_satoshis(amount: float, currency: str) -> float:
-    return float(amount * (await get_fiat_rate_satoshis(currency)))
+async def fiat_amount_as_satoshis(amount: float, currency: str) -> int:
+    amount_as_sattoshi = amount * (await get_fiat_rate_satoshis(currency))
+    amount_as_sattoshi =round(amount_as_sattoshi)
+    if amount_as_sattoshi==0:
+        amount_as_sattoshi=1
+    return int(amount_as_sattoshi)
 
 
 async def satoshis_amount_as_fiat(amount: float, currency: str) -> float:


### PR DESCRIPTION
As mentioned in lnbits#573 we would be happy if you adding the following to the project for the reasons mentioned:
1) Add Nobitex exchange, because many Iranians use this exchange and it is almost a price reference for digital currencies of this exchange.
2) Modify the output type of "fiat_amount_as_satoshis()" Function from int to float due to decimal output in converting Toman to Satoshi in int mode returns zero output.
For example : 1 IRT => 0.0104 Sat

Thanks & Regards
Amir Makouei