### PR TITLE
Fix HTML response to non browser request

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -59,16 +59,19 @@ def create_app(config_object="lnbits.settings") -> FastAPI:
     async def validation_exception_handler(
         request: Request, exc: RequestValidationError
     ):
+        # Only the browser sends "text/html" request
+        # not fail proof, but everything else get's a JSON response
         
         if "text/html" in request.headers["accept"]:
             return template_renderer().TemplateResponse(
                 "error.html",
-                {"request": request, "err": f"`{exc.errors()}` is not a valid UUID."},
-            )            
+                {"request": request, "err": f"{exc.errors()} is not a valid UUID."},
+            )    
 
+                    
         return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            content={"detail": exc.errors(), "body": exc.body},
+            content={"detail": exc.errors()},
         )
 
     app.add_middleware(GZipMiddleware, minimum_size=1000)

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -3,8 +3,9 @@ import importlib
 import sys
 import traceback
 import warnings
+from http import HTTPStatus
 
-from fastapi import FastAPI, Request, status
+from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
@@ -61,16 +62,15 @@ def create_app(config_object="lnbits.settings") -> FastAPI:
     ):
         # Only the browser sends "text/html" request
         # not fail proof, but everything else get's a JSON response
-        
+
         if "text/html" in request.headers["accept"]:
             return template_renderer().TemplateResponse(
                 "error.html",
                 {"request": request, "err": f"{exc.errors()} is not a valid UUID."},
             )    
 
-                    
         return JSONResponse(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=HTTPStatus.NO_CONTENT,
             content={"detail": exc.errors()},
         )
 


### PR DESCRIPTION
Apparently, a browser always includes `text/html,application/xhtml+xml,application/xml` in the "Accept" header (unless a user is messing with the kind of headers the browser sends). 

Main goal here is, check if the request is coming from a browser and send the error.html, else send a JSON response with the error.

Tested with CURL, Firefox and Chrome! Working as expected...