### PR TITLE
Added line wrapping for text in code examples

### DIFF
--- a/lnbits/static/scss/base.scss
+++ b/lnbits/static/scss/base.scss
@@ -141,3 +141,9 @@ video {
 .text-wrap {
     word-break: break-word;
 }
+
+.q-card {
+  code {
+    overflow-wrap: break-word;
+  }
+}


### PR DESCRIPTION
Added line wrapping for text in code examples to make it readable on normal sized screens