### PR TITLE
Fix Return 1 as a Minimum of Satoshi amount.

### DIFF
--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -180,6 +180,12 @@ class Provider(NamedTuple):
 
 
 exchange_rate_providers = {
+    "nobitex": Provider(
+        "Nobitex",
+        "nobitex.ir",
+        "https://api.nobitex.ir/v2/orderbook/{FROM}{TO}",
+        lambda data, replacements: data["lastTradePrice"],
+    ), 
     "exir": Provider(
         "Exir",
         "exir.io",
@@ -290,7 +296,11 @@ async def get_fiat_rate_satoshis(currency: str) -> float:
 
 
 async def fiat_amount_as_satoshis(amount: float, currency: str) -> int:
-    return int(amount * (await get_fiat_rate_satoshis(currency)))
+    amount_as_sattoshi = amount * (await get_fiat_rate_satoshis(currency))
+    amount_as_sattoshi = round(amount_as_sattoshi)
+    if amount_as_sattoshi==0:
+        amount_as_sattoshi=1
+    return int(amount_as_sattoshi)
 
 
 async def satoshis_amount_as_fiat(amount: float, currency: str) -> float:


### PR DESCRIPTION
As mentioned in lnbits#655 :

1) I changed the code when you did not accept to change the output type of the "fiat_amount_as_satoshis ()" function to float.
because of When the fiat currency price like IRT is lowest from satoshi, the function returns 0 and addon like BTCPOS can't calculate correct amount of satoshi and create invoice.
For example : 1 IRT => 0.0104 Sat then Function return 0,

2) Add Nobitex exchange, because many Iranians use this exchange and it is almost a price reference for digital currencies of this exchange.