### PR TITLE
Testing: postgres db backend

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,11 +3,11 @@ name: tests
 on: [push, pull_request]
 
 jobs:
-  unit-sqlite:
+  sqlite:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -27,7 +27,7 @@ jobs:
           ./venv/bin/pip install pytest pytest-asyncio pytest-cov requests mock
       - name: Run tests
         run: make test
-  unit-postgres:
+  postgres:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -46,7 +46,7 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
           python -m venv ${{ env.VIRTUAL_ENV }}
           ./venv/bin/python -m pip install --upgrade pip
           ./venv/bin/pip install -r requirements.txt
-          ./venv/bin/pip install pytest pytest-asyncio requests mock
+          ./venv/bin/pip install pytest pytest-asyncio pytest-cov requests mock
       - name: Run tests
         run: make test
   unit-postgres:
@@ -63,7 +63,7 @@ jobs:
           python -m venv ${{ env.VIRTUAL_ENV }}
           ./venv/bin/python -m pip install --upgrade pip
           ./venv/bin/pip install -r requirements.txt
-          ./venv/bin/pip install pytest pytest-asyncio requests mock
+          ./venv/bin/pip install pytest pytest-asyncio pytest-cov requests mock
       - name: Run tests
         env:
           LNBITS_DATABASE_URL: postgres://postgres:postgres@0.0.0.0:5432/postgres

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,21 +47,21 @@ jobs:
         run: make test
   postgres:
     runs-on: ubuntu-latest
-      services:
-        postgres:
-          image: postgres:latest
-          env:
-            POSTGRES_USER: postgres
-            POSTGRES_PASSWORD: postgres
-            POSTGRES_DB: postgres
-          ports:
-            # maps tcp port 5432 on service container to the host
-            - 5432:5432
-          options: >-
-            --health-cmd pg_isready
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          # maps tcp port 5432 on service container to the host
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       matrix:
         python-version: [3.8]
@@ -83,8 +83,8 @@ jobs:
           ./venv/bin/pip install -r requirements.txt
           ./venv/bin/pip install pytest pytest-asyncio requests trio mock
       - name: Run tests
-        # env:
-        #   LNBITS_DATABASE_URL: postgres://postgres:postgres@0.0.0.0:5432/postgres
+        env:
+          LNBITS_DATABASE_URL: postgres://postgres:postgres@0.0.0.0:5432/postgres
         run: make test
   # build:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,24 +3,8 @@ name: tests
 on: [push, pull_request]
 
 jobs:
-  unit:
+  unit-sqlite:
     runs-on: ubuntu-latest
-    # services:
-    #   postgres:
-    #     image: postgres:latest
-    #     env:
-    #       POSTGRES_USER: postgres
-    #       POSTGRES_PASSWORD: postgres
-    #       POSTGRES_DB: postgres
-    #     ports:
-    #       # maps tcp port 5432 on service container to the host
-    #       - 5432:5432
-    #     options: >-
-    #       --health-cmd pg_isready
-    #       --health-interval 10s
-    #       --health-timeout 5s
-    #       --health-retries 5
-
     strategy:
       matrix:
         python-version: [3.8]
@@ -40,12 +24,10 @@ jobs:
           python -m venv ${{ env.VIRTUAL_ENV }}
           ./venv/bin/python -m pip install --upgrade pip
           ./venv/bin/pip install -r requirements.txt
-          ./venv/bin/pip install pytest pytest-asyncio requests trio mock
+          ./venv/bin/pip install pytest pytest-asyncio requests mock
       - name: Run tests
-        # env:
-        #   LNBITS_DATABASE_URL: postgres://postgres:postgres@0.0.0.0:5432/postgres
         run: make test
-  postgres:
+  unit-postgres:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -81,7 +63,7 @@ jobs:
           python -m venv ${{ env.VIRTUAL_ENV }}
           ./venv/bin/python -m pip install --upgrade pip
           ./venv/bin/pip install -r requirements.txt
-          ./venv/bin/pip install pytest pytest-asyncio requests trio mock
+          ./venv/bin/pip install pytest pytest-asyncio requests mock
       - name: Run tests
         env:
           LNBITS_DATABASE_URL: postgres://postgres:postgres@0.0.0.0:5432/postgres

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,10 @@ jobs:
         env:
           LNBITS_DATABASE_URL: postgres://postgres:postgres@0.0.0.0:5432/postgres
         run: make test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
   # build:
   #   runs-on: ubuntu-latest
   #   strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,47 @@ jobs:
         # env:
         #   LNBITS_DATABASE_URL: postgres://postgres:postgres@0.0.0.0:5432/postgres
         run: make test
+  postgres:
+    runs-on: ubuntu-latest
+      services:
+        postgres:
+          image: postgres:latest
+          env:
+            POSTGRES_USER: postgres
+            POSTGRES_PASSWORD: postgres
+            POSTGRES_DB: postgres
+          ports:
+            # maps tcp port 5432 on service container to the host
+            - 5432:5432
+          options: >-
+            --health-cmd pg_isready
+            --health-interval 10s
+            --health-timeout 5s
+            --health-retries 5
+    strategy:
+      matrix:
+        python-version: [3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: psycopg2 prerequisites
+        run: sudo apt-get install python-dev libpq-dev
+      - name: Install dependencies
+        env: 
+          VIRTUAL_ENV: ./venv
+          PATH: ${{ env.VIRTUAL_ENV }}/bin:${{ env.PATH }}
+        run: |
+          python -m venv ${{ env.VIRTUAL_ENV }}
+          ./venv/bin/python -m pip install --upgrade pip
+          ./venv/bin/pip install -r requirements.txt
+          ./venv/bin/pip install pytest pytest-asyncio requests trio mock
+      - name: Run tests
+        # env:
+        #   LNBITS_DATABASE_URL: postgres://postgres:postgres@0.0.0.0:5432/postgres
+        run: make test
   # build:
   #   runs-on: ubuntu-latest
   #   strategy:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test:
 	FAKE_WALLET_SECRET="ToTheMoon1" \
 	LNBITS_DATA_FOLDER="./tests/data" \
 	PYTHONUNBUFFERED=1 \
-	./venv/bin/pytest -s
+	./venv/bin/pytest -s --cov=lnbits --cov-report=xml
 
 bak:
 	# LNBITS_DATABASE_URL=postgres://postgres:postgres@0.0.0.0:5432/postgres

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test:
 	FAKE_WALLET_SECRET="ToTheMoon1" \
 	LNBITS_DATA_FOLDER="./tests/data" \
 	PYTHONUNBUFFERED=1 \
-	./venv/bin/pytest -s --cov=lnbits --cov-report=xml
+	./venv/bin/pytest --durations=1 -s --cov=lnbits --cov-report=xml
 
 bak:
 	# LNBITS_DATABASE_URL=postgres://postgres:postgres@0.0.0.0:5432/postgres

--- a/docs/devs/development.md
+++ b/docs/devs/development.md
@@ -17,7 +17,7 @@ Tests
 
 This project has unit tests that help prevent regressions. Before you can run the tests, you must install a few dependencies:
 ```bash
-./venv/bin/pip install pytest pytest-asyncio requests trio mock
+./venv/bin/pip install pytest pytest-asyncio requests mock
 ```
 
 Then to run the tests:

--- a/docs/devs/development.md
+++ b/docs/devs/development.md
@@ -17,7 +17,7 @@ Tests
 
 This project has unit tests that help prevent regressions. Before you can run the tests, you must install a few dependencies:
 ```bash
-./venv/bin/pip install pytest pytest-asyncio requests mock
+./venv/bin/pip install pytest pytest-asyncio pytest-cov requests mock
 ```
 
 Then to run the tests:

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -394,13 +394,18 @@ async def api_payment(payment_hash, X_Api_Key: Optional[str] = Header(None)):
             print("No key")
     except:
         wallet = await get_wallet_for_key(X_Api_Key)
-    payment = await get_standalone_payment(payment_hash)
+    payment = await get_standalone_payment(
+        payment_hash, wallet_id=wallet.id if wallet else None
+    )  # we have to specify the wallet id here, because postgres and sqlite return internal payments in different order
+    # and get_standalone_payment otherwise just fetches the first one, causing unpredictable results
     if payment is None:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="Payment does not exist."
         )
     await check_invoice_status(payment.wallet_id, payment_hash)
-    payment = await get_standalone_payment(payment_hash)
+    payment = await get_standalone_payment(
+        payment_hash, wallet_id=wallet.id if wallet else None
+    )
     if not payment:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="Payment does not exist."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import asyncio
-import pytest
 import pytest_asyncio
+
 from httpx import AsyncClient
 from lnbits.app import create_app
 from lnbits.commands import migrate_databases

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 from lnbits.app import create_app
 from lnbits.commands import migrate_databases
@@ -15,7 +16,7 @@ from lnbits.core.models import User, Wallet, Payment, BalanceCheck
 from typing import Tuple
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 def event_loop():
     loop = asyncio.get_event_loop()
     yield loop
@@ -23,7 +24,7 @@ def event_loop():
 
 
 # use session scope to run once before and once after all tests
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 def app(event_loop):
     app = create_app()
     # use redefined version of the event loop for scope="session"
@@ -37,19 +38,19 @@ def app(event_loop):
     # loop.close()
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def client(app):
     client = AsyncClient(app=app, base_url=f"http://{HOST}:{PORT}")
     yield client
     await client.aclose()
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def db():
     yield Database("database")
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def from_user_wallet():
     user = await create_account()
     wallet = await create_wallet(user_id=user.id, wallet_name="test_wallet_from")
@@ -61,7 +62,7 @@ async def from_user_wallet():
     yield user, wallet
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def to_user_wallet():
     user = await create_account()
     wallet = await create_wallet(user_id=user.id, wallet_name="test_wallet_to")
@@ -73,7 +74,7 @@ async def to_user_wallet():
     yield user, wallet
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def inkey_headers_from(from_user_wallet):
     _, wallet = from_user_wallet
     yield {
@@ -82,7 +83,7 @@ async def inkey_headers_from(from_user_wallet):
     }
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def adminkey_headers_from(from_user_wallet):
     _, wallet = from_user_wallet
     yield {
@@ -91,7 +92,7 @@ async def adminkey_headers_from(from_user_wallet):
     }
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def inkey_headers_to(to_user_wallet):
     _, wallet = to_user_wallet
     yield {
@@ -100,7 +101,7 @@ async def inkey_headers_to(to_user_wallet):
     }
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def adminkey_headers_to(to_user_wallet):
     _, wallet = to_user_wallet
     yield {
@@ -109,7 +110,7 @@ async def adminkey_headers_to(to_user_wallet):
     }
 
 
-@pytest.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session")
 async def invoice(to_user_wallet):
     _, wallet = to_user_wallet
     data = await get_random_invoice_data()

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -57,18 +57,18 @@ async def test_check_payment_without_key(client, invoice):
     assert "details" not in response.json()
 
 
-# check GET /api/v1/payments/<hash>: payment status
-@pytest.mark.asyncio
-async def test_check_payment_with_key(client, invoice, inkey_headers_from):
-    # check the payment status
-    response = await client.get(
-        f"/api/v1/payments/{invoice['payment_hash']}", headers=inkey_headers_from
-    )
-    assert response.status_code < 300
-    assert response.json()["paid"] == True
-    assert invoice
-    # with key, that's why with "details"
-    assert "details" in response.json()
+# # check GET /api/v1/payments/<hash>: payment status
+# @pytest.mark.asyncio
+# async def test_check_payment_with_key(client, invoice, inkey_headers_from):
+#     # check the payment status
+#     response = await client.get(
+#         f"/api/v1/payments/{invoice['payment_hash']}", headers=inkey_headers_from
+#     )
+#     assert response.status_code < 300
+#     assert response.json()["paid"] == True
+#     assert invoice
+#     # with key, that's why with "details"
+#     assert "details" in response.json()
 
 
 # check POST /api/v1/payments: payment with wrong key type

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -57,18 +57,22 @@ async def test_check_payment_without_key(client, invoice):
     assert "details" not in response.json()
 
 
-# # check GET /api/v1/payments/<hash>: payment status
-# @pytest.mark.asyncio
-# async def test_check_payment_with_key(client, invoice, inkey_headers_from):
-#     # check the payment status
-#     response = await client.get(
-#         f"/api/v1/payments/{invoice['payment_hash']}", headers=inkey_headers_from
-#     )
-#     assert response.status_code < 300
-#     assert response.json()["paid"] == True
-#     assert invoice
-#     # with key, that's why with "details"
-#     assert "details" in response.json()
+# check GET /api/v1/payments/<hash>: payment status
+# NOTE: this test is sensitive to which db is used.
+# If postgres: it will succeed only with inkey_headers_to
+# If sqlite: it will succeed only with adminkey_headers_from
+# TODO: fix this
+@pytest.mark.asyncio
+async def test_check_payment_with_key(client, invoice, inkey_headers_from):
+    # check the payment status
+    response = await client.get(
+        f"/api/v1/payments/{invoice['payment_hash']}", headers=inkey_headers_from
+    )
+    assert response.status_code < 300
+    assert response.json()["paid"] == True
+    assert invoice
+    # with key, that's why with "details"
+    assert "details" in response.json()
 
 
 # check POST /api/v1/payments: payment with wrong key type

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -59,10 +59,10 @@ async def test_check_payment_without_key(client, invoice):
 
 # check GET /api/v1/payments/<hash>: payment status
 @pytest.mark.asyncio
-async def test_check_payment_with_key(client, invoice, inkey_headers_to):
+async def test_check_payment_with_key(client, invoice, inkey_headers_from):
     # check the payment status
     response = await client.get(
-        f"/api/v1/payments/{invoice['payment_hash']}", headers=inkey_headers_to
+        f"/api/v1/payments/{invoice['payment_hash']}", headers=inkey_headers_from
     )
     assert response.status_code < 300
     assert response.json()["paid"] == True

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -59,8 +59,8 @@ async def test_check_payment_without_key(client, invoice):
 
 # check GET /api/v1/payments/<hash>: payment status
 # NOTE: this test is sensitive to which db is used.
-# If postgres: it will succeed only with inkey_headers_to
-# If sqlite: it will succeed only with adminkey_headers_from
+# If postgres: it will succeed only with inkey_headers_from
+# If sqlite: it will succeed only with adminkey_headers_to
 # TODO: fix this
 @pytest.mark.asyncio
 async def test_check_payment_with_key(client, invoice, inkey_headers_from):

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 from lnbits.core.crud import get_wallet
 
 from ...helpers import get_random_invoice_data

--- a/tests/core/views/test_generic.py
+++ b/tests/core/views/test_generic.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 from tests.conftest import client
 
 

--- a/tests/core/views/test_public_api.py
+++ b/tests/core/views/test_public_api.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 from lnbits.core.crud import get_wallet
 
 # check if the client is working

--- a/tests/extensions/bleskomat/conftest.py
+++ b/tests/extensions/bleskomat/conftest.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import pytest_asyncio
 import secrets
 from lnbits.core.crud import create_account, create_wallet
 from lnbits.extensions.bleskomat.crud import create_bleskomat, create_bleskomat_lnurl
@@ -20,7 +21,7 @@ exchange_rate_providers["dummy"] = {
 }
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def bleskomat():
     user = await create_account()
     wallet = await create_wallet(user_id=user.id, wallet_name="bleskomat_test")
@@ -34,7 +35,7 @@ async def bleskomat():
     return bleskomat
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def lnurl(bleskomat):
     query = {
         "tag": "withdrawRequest",

--- a/tests/extensions/bleskomat/test_lnurl_api.py
+++ b/tests/extensions/bleskomat/test_lnurl_api.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 import secrets
 from lnbits.core.crud import get_wallet
 from lnbits.settings import HOST, PORT

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,12 +1,9 @@
-import time
 from mock import AsyncMock
 from lnbits import bolt11
 from lnbits.wallets.base import (
     StatusResponse,
-    InvoiceResponse,
     PaymentResponse,
     PaymentStatus,
-    Wallet,
 )
 from lnbits.settings import WALLET
 


### PR DESCRIPTION
This PR has several improvements for automated testing:
* New PostgreSQL testing pipeline
* Measure code coverage and upload to codecov
* Fix a bug* in `api_payment` that only appears with sqlite.

_*Details about the bug:_

`api_payment` or `GET /api/v1/payments/{payment_hash}` can be used with or without the invoice key of the owner of the payment. If no valid key is provided, it returns no payment details via `get_standalone_payment`, otherwise it does.  For internal payments, the backend created two entries, one debit and one credit. Both of these payments have the same `payment_hash` which can lead to a collision when `get_standalone_payment` looks up the payment. This was never noticed because the database used (sqlite) has always put the transactions in a deterministic order. Postgres switches this ordering, writing the credit before the debit transaction to the database. Therefore, a wrong transaction (the debit one) was always pulled, which didn't match the wallet id determined by the invoice key given above. 

Fix: additional argument for `get_standalone_payment` which can specify the wallet id the `payment_hash` belongs to, allowing us to select the transaction we want (debit or credit). 