### PR TITLE
Spark: increase timeout and improved error handling

### DIFF
--- a/lnbits/wallets/spark.py
+++ b/lnbits/wallets/spark.py
@@ -56,6 +56,7 @@ class SparkWallet(Wallet):
                 httpx.ConnectError,
                 httpx.RequestError,
                 httpx.HTTPError,
+                httpx.TimeoutException,
             ) as exc:
                 raise UnknownError("error connecting to spark: " + str(exc))
 

--- a/lnbits/wallets/spark.py
+++ b/lnbits/wallets/spark.py
@@ -48,7 +48,7 @@ class SparkWallet(Wallet):
                         self.url + "/rpc",
                         headers={"X-Access": self.token},
                         json={"method": key, "params": params},
-                        timeout=40,
+                        timeout=60 * 60 * 24,
                     )
             except (OSError, httpx.ConnectError, httpx.RequestError) as exc:
                 raise UnknownError("error connecting to spark: " + str(exc))

--- a/lnbits/wallets/spark.py
+++ b/lnbits/wallets/spark.py
@@ -50,7 +50,13 @@ class SparkWallet(Wallet):
                         json={"method": key, "params": params},
                         timeout=60 * 60 * 24,
                     )
-            except (OSError, httpx.ConnectError, httpx.RequestError) as exc:
+                    r.raise_for_status()
+            except (
+                OSError,
+                httpx.ConnectError,
+                httpx.RequestError,
+                httpx.HTTPError,
+            ) as exc:
                 raise UnknownError("error connecting to spark: " + str(exc))
 
             try:
@@ -203,7 +209,13 @@ class SparkWallet(Wallet):
                                 data = json.loads(line[5:])
                                 if "pay_index" in data and data.get("status") == "paid":
                                     yield data["label"]
-            except (OSError, httpx.ReadError, httpx.ConnectError, httpx.ReadTimeout):
+            except (
+                OSError,
+                httpx.ReadError,
+                httpx.ConnectError,
+                httpx.ReadTimeout,
+                httpx.HTTPError,
+            ):
                 pass
 
             logger.error("lost connection to spark /stream, retrying in 5 seconds")


### PR DESCRIPTION
Minimizes the risk of stuck payments due to timeouts in `spark` backend.

* Timeout for `WALLET.call` increased from 40s to 24 hours. 
* `requests.raise_for_status()` added to `WALLET.call`
* catch `httpx.TimeoutException` in `WALLET.call`
* catch `httpx.HTTPError` in `paid_invoices_stream`
