### PR TITLE
Add NFC Writing support to LNURLw extension

### DIFF
--- a/lnbits/extensions/withdraw/static/js/index.js
+++ b/lnbits/extensions/withdraw/static/js/index.js
@@ -53,6 +53,7 @@ new Vue({
           rowsPerPage: 10
         }
       },
+      nfcTagWriting: false,
       formDialog: {
         show: false,
         secondMultiplier: 'seconds',
@@ -230,6 +231,36 @@ new Vue({
               LNbits.utils.notifyApiError(error)
             })
         })
+    },
+    writeNfcTag: async function (lnurl) {
+      try {
+        if (typeof NDEFReader == 'undefined') {
+          throw {
+            toString: function () {
+              return 'NFC not supported on this device and/or browser.'
+            }
+          }
+        }
+
+        const ndef = new NDEFReader()
+
+        this.nfcTagWriting = true
+        this.$q.notify({
+          message: 'Tap your NFC tag now to write the LNURLw to it'
+        })
+
+        await ndef.write(lnurl)
+
+        this.nfcTagWriting = false
+        this.$q.notify({
+          message: 'NFC Tag written successfully!'
+        })
+      } catch (error) {
+        this.nfcTagWriting = false
+        this.$q.notify({
+          message: error ? error.toString() : 'An unexpected error has occurred'
+        })
+      }
     },
     exportCSV: function () {
       LNbits.utils.exportCSV(this.paywallsTable.columns, this.paywalls)

--- a/lnbits/extensions/withdraw/templates/withdraw/display.html
+++ b/lnbits/extensions/withdraw/templates/withdraw/display.html
@@ -17,10 +17,17 @@
             </q-responsive>
           </a>
         </div>
-        <div class="row q-mt-lg">
+        <div class="row q-mt-lg q-gutter-sm">
           <q-btn outline color="grey" @click="copyText('{{ lnurl }}')"
             >Copy LNURL</q-btn
           >
+          <q-btn
+            outline
+            color="grey"
+            icon="nfc"
+            @click="writeNfcTag(' {{ lnurl }} ')"
+            :disable="nfcTagWriting"
+          ></q-btn>
         </div>
       </q-card-section>
     </q-card>
@@ -51,7 +58,42 @@
     mixins: [windowMixin],
     data: function () {
       return {
-        here: location.protocol + '//' + location.host
+        here: location.protocol + '//' + location.host,
+        nfcTagWriting: false
+      }
+    },
+    methods: {
+      writeNfcTag: async function (lnurl) {
+        try {
+          if (typeof NDEFReader == 'undefined') {
+            throw {
+              toString: function () {
+                return 'NFC not supported on this device and/or browser.'
+              }
+            }
+          }
+
+          const ndef = new NDEFReader()
+
+          this.nfcTagWriting = true
+          this.$q.notify({
+            message: 'Tap your NFC tag now to write the LNURLw to it'
+          })
+
+          await ndef.write(lnurl)
+
+          this.nfcTagWriting = false
+          this.$q.notify({
+            message: 'NFC Tag written successfully!'
+          })
+        } catch (error) {
+          this.nfcTagWriting = false
+          this.$q.notify({
+            message: error
+              ? error.toString()
+              : 'An unexpected error has occurred'
+          })
+        }
       }
     }
   })

--- a/lnbits/extensions/withdraw/templates/withdraw/index.html
+++ b/lnbits/extensions/withdraw/templates/withdraw/index.html
@@ -372,6 +372,13 @@
         <q-btn
           outline
           color="grey"
+          icon="nfc"
+          @click="writeNfcTag(qrCodeDialog.data.lnurl)"
+          :disable="nfcTagWriting"
+        ></q-btn>
+        <q-btn
+          outline
+          color="grey"
           icon="print"
           type="a"
           :href="qrCodeDialog.data.print_url"


### PR DESCRIPTION
This PR adds a button to the LNURLw extension that allows a user to write their bech32-encoded withdraw string to a NDEF NFC card.

There's a new NFC button in the details modal window:

<img width="513" alt="Screen Shot 2022-07-09 at 7 19 23 PM" src="https://user-images.githubusercontent.com/3018359/178127690-a59f9bb2-7e86-42ea-97b7-f0b2f07a055a.png">

There's a new NFC button in the shareable link page:

<img width="989" alt="Screen Shot 2022-07-09 at 7 19 59 PM" src="https://user-images.githubusercontent.com/3018359/178127696-37004f14-da2a-4e76-b272-2331a4992ff5.png">

One important note is that this is currently only supported in Chrome for Android >=89.

Now that BTCPayServer supports LNURLw over NFC at checkout, adding this to LNBits will allow users to load up some sats to a card/wristband/necklace/implant/whatever and pay at many merchants without their phone.