### PR TITLE
Revert "Fixed psycopg2 error on aarch64"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ loguru==0.6.0
 markupsafe==2.0.1
 marshmallow==3.13.0
 outcome==1.1.0
-psycopg2==2.9.3
+psycopg2-binary==2.9.1
 pycryptodomex==3.14.1
 pydantic==1.8.2
 pypng==0.0.21


### PR DESCRIPTION
Reverts lnbits/lnbits-legend#658

Having users install universal dependencies is not something LNbits does.

Our use of psycopg is not advanced so we should revert the pr

https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary