### PR TITLE
error in `/usermanager/api/v1/extensions`

### DIFF
--- a/lnbits/extensions/usermanager/views_api.py
+++ b/lnbits/extensions/usermanager/views_api.py
@@ -75,7 +75,7 @@ async def api_usermanager_activate_extension(
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="User does not exist."
         )
-    update_user_extension(user_id=userid, extension=extension, active=active)
+    await update_user_extension(user_id=userid, extension=extension, active=active)
     return {"extension": "updated"}
 
 


### PR DESCRIPTION
Requests to `POST /usermanager/api/v1/extensions` would silently fail due to a missing `await`.