### PR TITLE
use loguru formatting for uvicorn logs

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -5,6 +5,7 @@ import traceback
 import warnings
 import logging
 
+
 from loguru import logger
 
 from http import HTTPStatus
@@ -216,10 +217,4 @@ class InterceptHandler(logging.Handler):
             level = logger.level(record.levelname).name
         except ValueError:
             level = record.levelno
-        frame, depth = logging.currentframe(), 2
-        while frame.f_code.co_filename == logging.__file__:
-            frame = frame.f_back
-            depth += 1
-        logger.opt(depth=depth, exception=record.exc_info).log(
-            level, record.getMessage()
-        )
+        logger.log(level, record.getMessage())


### PR DESCRIPTION
added a intercept handler for uvicorn and uvicorn.access (fastapi)

explained here https://loguru.readthedocs.io/en/stable/overview.html#entirely-compatible-with-standard-logging
