### PR TITLE
`FakeWallet`: do not mark payments as failed

### DIFF
--- a/lnbits/wallets/fake.py
+++ b/lnbits/wallets/fake.py
@@ -91,10 +91,10 @@ class FakeWallet(Wallet):
             )
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
-        return PaymentStatus(False)
+        return PaymentStatus(None)
 
     async def get_payment_status(self, checking_id: str) -> PaymentStatus:
-        return PaymentStatus(False)
+        return PaymentStatus(None)
 
     async def paid_invoices_stream(self) -> AsyncGenerator[str, None]:
         self.queue = asyncio.Queue(0)


### PR DESCRIPTION
Fixes #749.