### PR TITLE
LNURLw: change prefix to `lightning:` until wallets fix their bugs

### DIFF
--- a/lnbits/extensions/withdraw/static/js/index.js
+++ b/lnbits/extensions/withdraw/static/js/index.js
@@ -250,7 +250,7 @@ new Vue({
         })
 
         await ndef.write({
-          records: [{recordType: 'url', data: 'lnurlw://' + lnurl, lang: 'en'}]
+          records: [{recordType: 'url', data: 'lightning:' + lnurl, lang: 'en'}]
         })
 
         this.nfcTagWriting = false


### PR DESCRIPTION
* [This](https://github.com/fiatjaf/lnurl-rfc/pull/66#issuecomment-868407854=) says you should use `lnurlw:`
* [This](https://github.com/fiatjaf/lnurl-rfc/blob/luds/17.md) says you should use `lnurlw://`
* Wallet of Satoshi parses `lnurlw://abc` to `//abc`
* Breez can handle it all
* I'm gonna use `lightning:` because I got mad.