### PR TITLE
CI: Test `core/views/generic.py` enabling and disabling extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Wallets can be easily generated and given out to people at events (one click mul
 
 ## Tip us
 
-If you like this project and might even use or extend it, why not [send some tip love](https://lnbits.com/paywall/GAqKguK5S8f6w5VNjS9DfK)!
+If you like this project and might even use or extend it, why not [send some tip love](https://legend.lnbits.com/paywall/GAqKguK5S8f6w5VNjS9DfK)!
 
 
 [docs]: https://lnbits.org/

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -23,6 +23,10 @@ from lnbits.settings import (
     SERVICE_FEE,
 )
 
+from ...helpers import (
+    get_valid_extensions,
+)
+
 from ..crud import (
     create_account,
     create_wallet,
@@ -65,6 +69,14 @@ async def extensions(
         raise HTTPException(
             HTTPStatus.BAD_REQUEST, "You can either `enable` or `disable` an extension."
         )
+
+    # check if extension exists
+    if extension_to_enable or extension_to_disable:
+        ext = extension_to_enable or extension_to_disable
+        if ext not in [e.code for e in get_valid_extensions()]:
+            raise HTTPException(
+                HTTPStatus.BAD_REQUEST, f"Extension '{ext}' doesn't exist."
+            )
 
     if extension_to_enable:
         logger.info(f"Enabling extension: {extension_to_enable} for user {user.id}")

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -23,10 +23,7 @@ from lnbits.settings import (
     SERVICE_FEE,
 )
 
-from ...helpers import (
-    get_valid_extensions,
-)
-
+from ...helpers import get_valid_extensions
 from ..crud import (
     create_account,
     create_wallet,

--- a/tests/core/views/test_generic.py
+++ b/tests/core/views/test_generic.py
@@ -108,6 +108,15 @@ async def test_get_extensions(client, to_user):
     )
 
 
+# check GET /extensions: extensions list wrong user, expect 204
+@pytest.mark.asyncio
+async def test_get_extensions_wrong_user(client, to_user):
+    response = await client.get("extensions", params={"usr": "1"})
+    assert response.status_code == 204, (
+        str(response.url) + " " + str(response.status_code)
+    )
+
+
 # check GET /extensions: no user given, expect code 204 no content
 @pytest.mark.asyncio
 async def test_get_extensions_no_user(client):

--- a/tests/core/views/test_generic.py
+++ b/tests/core/views/test_generic.py
@@ -92,8 +92,60 @@ async def test_get_wallet_with_user_and_wallet(client, to_user, to_wallet):
 
 # check GET /wallet: wrong wallet and user, expect 204
 @pytest.mark.asyncio
-async def test_get_wallet_with_user_and_wrong_wallet(client, to_user, to_wallet):
+async def test_get_wallet_with_user_and_wrong_wallet(client, to_user):
     response = await client.get("wallet", params={"usr": to_user.id, "wal": "1"})
     assert response.status_code == 204, (
+        str(response.url) + " " + str(response.status_code)
+    )
+
+
+# check GET /extensions: extensions list
+@pytest.mark.asyncio
+async def test_get_extensions(client, to_user):
+    response = await client.get("extensions", params={"usr": to_user.id})
+    assert response.status_code == 200, (
+        str(response.url) + " " + str(response.status_code)
+    )
+
+
+# check GET /extensions: no user given, expect code 204 no content
+@pytest.mark.asyncio
+async def test_get_extensions_no_user(client):
+    response = await client.get("extensions")
+    assert response.status_code == 204, (  # no content
+        str(response.url) + " " + str(response.status_code)
+    )
+
+
+# check GET /extensions: enable extension
+@pytest.mark.asyncio
+async def test_get_extensions_enable(client, to_user):
+    response = await client.get(
+        "extensions", params={"usr": to_user.id, "enable": "lnurlp"}
+    )
+    assert response.status_code == 200, (
+        str(response.url) + " " + str(response.status_code)
+    )
+
+
+# check GET /extensions: enable nonexistent extension, expect code 400 bad request
+@pytest.mark.asyncio
+async def test_get_extensions_enable_nonexistent_extension(client, to_user):
+    response = await client.get(
+        "extensions", params={"usr": to_user.id, "enable": "12341234"}
+    )
+    assert response.status_code == 400, (
+        str(response.url) + " " + str(response.status_code)
+    )
+
+
+# check GET /extensions: enable and disable extensions, expect code 400 bad request
+@pytest.mark.asyncio
+async def test_get_extensions_enable_and_disable(client, to_user):
+    response = await client.get(
+        "extensions",
+        params={"usr": to_user.id, "enable": "lnurlp", "disable": "lnurlp"},
+    )
+    assert response.status_code == 400, (
         str(response.url) + " " + str(response.status_code)
     )


### PR DESCRIPTION
* Check whether extension exists before enabling/disabling (in `core/views/generic.py`)
* Tests
```
GET /extensions
GET /extensions?usr=1
GET /extensions?usr=1a02ca2c80bd8492396cd2803bb74d8b8
GET /extensions?usr=1a02ca2c80bd8492396cd2803bb74d8b8&enable=lnurlp
GET /extensions?usr=1a02ca2c80bd8492396cd2803bb74d8b8&enable=lnurlp&disable=lnurlp
GET /extensions?usr=1a02ca2c80bd8492396cd2803bb74d8b8&enable=wrong_extension
```