### PR TITLE
faster regtest, docker build is not needed anymore

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -16,7 +16,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Setup Regtest
         run: |
-          docker build -t lnbits-legend .
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
           chmod +x ./tests
@@ -39,8 +38,8 @@ jobs:
           LNBITS_DATA_FOLDER: ./data
           LNBITS_BACKEND_WALLET_CLASS: LndRestWallet
           LND_REST_ENDPOINT: https://localhost:8081/
-          LND_REST_CERT: docker/data/lnd-1/tls.cert
-          LND_REST_MACAROON: docker/data/lnd-1/data/chain/bitcoin/regtest/admin.macaroon
+          LND_REST_CERT: ./docker/data/lnd-1/tls.cert
+          LND_REST_MACAROON: ./docker/data/lnd-1/data/chain/bitcoin/regtest/admin.macaroon
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
@@ -57,7 +56,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Setup Regtest
         run: |
-          docker build -t lnbits-legend .
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
           chmod +x ./tests
@@ -79,7 +77,7 @@ jobs:
           PORT: 5123
           LNBITS_DATA_FOLDER: ./data
           LNBITS_BACKEND_WALLET_CLASS: CLightningWallet
-          CLIGHTNING_RPC: docker/data/clightning-1/regtest/lightning-rpc
+          CLIGHTNING_RPC: ./docker/data/clightning-1/regtest/lightning-rpc
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
+          git checkout removelnbits
           chmod +x ./tests
           ./tests
           sudo chmod -R a+rwx .
@@ -58,6 +59,7 @@ jobs:
         run: |
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
+          git checkout removelnbits
           chmod +x ./tests
           ./tests
           sudo chmod -R a+rwx .


### PR DESCRIPTION
recent PR of legend-regtest-enviroment does not include lnbits anymore, so we dont need to build it inside the regtest setup workflow anymore.
https://github.com/lnbits/legend-regtest-enviroment/pull/4
