### PR TITLE
fix test warnings when using < python3.8

### DIFF
--- a/lnbits/bolt11.py
+++ b/lnbits/bolt11.py
@@ -61,7 +61,7 @@ def decode(pr: str) -> Invoice:
     invoice = Invoice()
 
     # decode the amount from the hrp
-    m = re.search("[^\d]+", hrp[2:])
+    m = re.search(r"[^\d]+", hrp[2:])
     if m:
         amountstr = hrp[2 + m.end() :]
         if amountstr != "":
@@ -296,7 +296,7 @@ def _unshorten_amount(amount: str) -> int:
     # BOLT #11:
     # A reader SHOULD fail if `amount` contains a non-digit, or is followed by
     # anything except a `multiplier` in the table above.
-    if not re.fullmatch("\d+[pnum]?", str(amount)):
+    if not re.fullmatch(r"\d+[pnum]?", str(amount)):
         raise ValueError("Invalid amount '{}'".format(amount))
 
     if unit in units:

--- a/lnbits/jinja2_templating.py
+++ b/lnbits/jinja2_templating.py
@@ -21,7 +21,7 @@ class Jinja2Templates(templating.Jinja2Templates):
         self.env = self.get_environment(loader)
 
     def get_environment(self, loader: "jinja2.BaseLoader") -> "jinja2.Environment":
-        @jinja2.contextfunction
+        @jinja2.pass_context
         def url_for(context: dict, name: str, **path_params: typing.Any) -> str:
             request: Request = context["request"]
             return request.app.url_path_for(name, **path_params)


### PR DESCRIPTION
warning in bolt11.py:
`DeprecationWarning: invalid escape sequence \d`

warning in jinja:
`DeprecationWarning: 'contextfunction' is renamed to 'pass_context', the old name will be removed`

![screenshot-1659002794](https://user-images.githubusercontent.com/1743657/181480714-8d00306d-54e8-454f-a720-1be989fb5dbe.jpg)
