### PR TITLE
nix: add defaultText to services.lnbits.package

### DIFF
--- a/nix/modules/lnbits-service.nix
+++ b/nix/modules/lnbits-service.nix
@@ -3,7 +3,7 @@
 let
   defaultUser = "lnbits";
   cfg = config.services.lnbits;
-  inherit (lib) mkOption mkIf types optionalAttrs;
+  inherit (lib) mkOption mkIf types optionalAttrs literalExpression;
 in
 
 {
@@ -25,6 +25,7 @@ in
       };
       package = mkOption {
         type = types.package;
+        defaultText = literalExpression "pkgs.lnbits";
         default = pkgs.lnbits;
         description = ''
           The lnbits package to use.


### PR DESCRIPTION
Without this, evaluating the module doesn't provide a default value visible on search.nixos.org

This is needed to merge https://github.com/NixOS/nixos-search/pull/510