### PR TITLE
Mega-merge 1: Test invoice creation with description hash (WIP)

### DIFF
--- a/lnbits/bolt11.py
+++ b/lnbits/bolt11.py
@@ -216,7 +216,11 @@ def lnencode(addr, privkey):
                 expirybits = expirybits[5:]
             data += tagged("x", expirybits)
         elif k == "h":
-            data += tagged_bytes("h", hashlib.sha256(v.encode("utf-8")).digest())
+            # previously: assume that description_hash is a string that needs to be hashed
+            # data += tagged_bytes("h", hashlib.sha256(v.encode("utf-8")).digest())
+            data += tagged_bytes(
+                "h", unhexlify(v)
+            )  # assume that description_hash is a hash already
         elif k == "n":
             data += tagged_bytes("n", v)
         else:

--- a/lnbits/bolt11.py
+++ b/lnbits/bolt11.py
@@ -216,11 +216,7 @@ def lnencode(addr, privkey):
                 expirybits = expirybits[5:]
             data += tagged("x", expirybits)
         elif k == "h":
-            # previously: assume that description_hash is a string that needs to be hashed
-            # data += tagged_bytes("h", hashlib.sha256(v.encode("utf-8")).digest())
-            data += tagged_bytes(
-                "h", unhexlify(v)
-            )  # assume that description_hash is a hash already
+            data += tagged_bytes("h", hashlib.sha256(v.encode("utf-8")).digest())
         elif k == "n":
             data += tagged_bytes("n", v)
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest_asyncio
 
-from httpx import AsyncClient
+from httpx import Client, AsyncClient
 from lnbits.app import create_app
 from lnbits.commands import migrate_databases
 from lnbits.settings import HOST, PORT
@@ -122,12 +122,11 @@ async def adminkey_headers_to(to_wallet):
 
 @pytest_asyncio.fixture(scope="session")
 async def invoice(to_wallet):
-    wallet = to_wallet
     data = await get_random_invoice_data()
     invoiceData = CreateInvoiceData(**data)
     stuff_lock = asyncio.Lock()
     async with stuff_lock:
-        invoice = await api_payments_create_invoice(invoiceData, wallet)
-    await asyncio.sleep(1)
+        invoice = await api_payments_create_invoice(invoiceData, to_wallet)
+    # await asyncio.sleep(1)
     yield invoice
     del invoice

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest_asyncio
 
-from httpx import Client, AsyncClient
+from httpx import AsyncClient
 from lnbits.app import create_app
 from lnbits.commands import migrate_databases
 from lnbits.settings import HOST, PORT
@@ -124,9 +124,6 @@ async def adminkey_headers_to(to_wallet):
 async def invoice(to_wallet):
     data = await get_random_invoice_data()
     invoiceData = CreateInvoiceData(**data)
-    stuff_lock = asyncio.Lock()
-    async with stuff_lock:
-        invoice = await api_payments_create_invoice(invoiceData, to_wallet)
-    # await asyncio.sleep(1)
+    invoice = await api_payments_create_invoice(invoiceData, to_wallet)
     yield invoice
     del invoice

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -188,7 +188,7 @@ async def test_api_payment_with_key(invoice, inkey_headers_from):
     assert "details" in response
 
 
-# check POST /api/v1/payments: invoice creation for internal payments only
+# check POST /api/v1/payments: invoice creation with a description hash
 @pytest.mark.asyncio
 async def test_create_invoice_with_description_hash(client, inkey_headers_to):
     data = await get_random_invoice_data()

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -188,15 +188,6 @@ async def test_api_payment_with_key(invoice, inkey_headers_from):
     assert "details" in response
 
 
-# @pytest.mark.asyncio
-# async def test_create_invoice_with_description_hash(from_wallet):
-#     data = await get_random_invoice_data()
-#     data["description_hash"] = "0x" + sha256("test").hexdigest()
-#     invoiceData = CreateInvoiceData(**data)
-#     invoice = await api_payments_create_invoice(invoiceData, from_wallet)
-#     return invoice
-
-
 # check POST /api/v1/payments: invoice creation for internal payments only
 @pytest.mark.asyncio
 async def test_create_invoice_with_description_hash(client, inkey_headers_to):
@@ -211,10 +202,4 @@ async def test_create_invoice_with_description_hash(client, inkey_headers_to):
     invoice_bolt11 = bolt11.decode(invoice["payment_request"])
     assert invoice_bolt11.description_hash == descr_hash
     assert invoice_bolt11.description is None
-    assert response.status_code == 201
-    assert "payment_hash" in invoice
-    assert len(invoice["payment_hash"]) == 64
-    assert "payment_request" in invoice
-    assert "checking_id" in invoice
-    assert len(invoice["checking_id"])
     return invoice

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -193,12 +193,13 @@ async def test_api_payment_with_key(invoice, inkey_headers_from):
 async def test_create_invoice_with_description_hash(client, inkey_headers_to):
     data = await get_random_invoice_data()
     descr_hash = hashlib.sha256("asdasdasd".encode("utf-8")).hexdigest()
-    data["description_hash"] = descr_hash
+    data["description_hash"] = "asdasdasd".encode("utf-8").hex()
 
     response = await client.post(
         "/api/v1/payments", json=data, headers=inkey_headers_to
     )
     invoice = response.json()
+
     invoice_bolt11 = bolt11.decode(invoice["payment_request"])
     assert invoice_bolt11.description_hash == descr_hash
     assert invoice_bolt11.description is None


### PR DESCRIPTION
# The Mega-merge

This is the first PR of the Mega-merge series. The ultimate goal of the Mega-merge series it to use updated CLN and LND libraries and fix the use of `description_hash` for all wallets (which ultimately enables LNURL).

The Mega-merge series is separated into following parts in order to avoid total chaos and make review easier. All successive PRs have their predecessor merged into them already which is why the number of changed files is deceivingly large for the later PRs (they should go down as we merge one by one). 

Dependency graph:

```
                      ┌───┐
Tests    Refactor   ┌─┤MM3│ CLN
┌────┐     ┌───┐    │ └───┘
│MM1 ├─────►MM2├────►
└────┘     └───┘    │ ┌───┐
                    └─┤MM4│ LND
                      └───┘
```

### Mega-merge 1: Test invoice creation with `description_hash` (PR #812)
The purpose of this (present) PR is to add tests for invoice creation via the endpoint `/api/v1/payments` with `description_hash`. The tests are **expected to fail** but should succeed after the successive fixes in following merges. 

### Mega-merge 2: Refactor `description_hash` handling (PR #814)
This PR refactors how `description_hash` in handled in LNbits. Since most wallets (LND, Eclair, web-wallets) expect the **hash** of the description and others (CLN and FakeWallet/bolt11) expect the description itself, the process of hashing needs to be refactored to the very end of the pipeline into the wallets itself. Before, LNbits was hashing the description in all LNURL operations before calling `create_invoice`. After this PR, LNbits will pass the description and the wallet decides to hash it or not

### Mega-merge 3: Update CLN to use `description_hash` (PR #792)
This PR updates the CLN library and enables the native use of `description_hash`. This PR is the reason why the previous two PR's exist. They are separated so that the previous parts can be merged before the lib is updated. 

### Mega-merge 4: Reenable LND GRPC and update invoice status checking (PR #745)
This PR is not directly related to the previous ones and could be merged separately. Here we updated the RPC stub to the latest version and use `TrackPaymentV2` to check whether an outgoing payment has succeeded or not.

### To be continued...
The end of this series (which I will tackle some other day after we merged all this) will be a new payment checking flow in which the payment will be created in the backend asynchronously and a task is kicked off that regularly checks the status of the payment. In theory, this should get rid of stuck payments. A precondition for this would be that all payments are written to the LNbits database with their `payment_hash` as the `checking_id` and not some post-hoc label that we only know when the payment is sent to the backend. More thoughts on this are written down in the notes of PR #745.