### PR TITLE
make instant wallet available in custom vouchers

### DIFF
--- a/lnbits/extensions/withdraw/templates/withdraw/print_qr_custom.html
+++ b/lnbits/extensions/withdraw/templates/withdraw/print_qr_custom.html
@@ -9,7 +9,10 @@
         <img src="{{custom_url}}" alt="..." />
         <span>{{ amt }} sats</span>
         <div class="lnurlw">
-          <qrcode :value="'{{one}}'" :options="{width: 95, margin: 1}"></qrcode>
+          <qrcode
+            :value="theurl + '/?lightning={{one}}'"
+            :options="{width: 95, margin: 1}"
+          ></qrcode>
         </div>
       </div>
       {% endfor %}


### PR DESCRIPTION
Make the custom designed vouchers QR have the instant wallet capability, when scanned with a normal QR scanner! 