### PR TITLE
Make `poetry run lnbits` use `.env` variables and fix uvicorn logs

### DIFF
--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -1,18 +1,13 @@
-import click
 import uvicorn
+from lnbits.settings import HOST, PORT
 
 
-@click.command()
-@click.option("--port", default="5000", help="Port to run LNBits on")
-@click.option("--host", default="127.0.0.1", help="Host to run LNBits on")
-def main(port, host):
+def main():
     """Launched with `poetry run lnbits` at root level"""
-    uvicorn.run("lnbits.__main__:app", port=port, host=host)
+    config = uvicorn.Config("lnbits.__main__:app", port=PORT, host=HOST)
+    server = uvicorn.Server(config)
+    server.run()
 
 
 if __name__ == "__main__":
     main()
-
-# def main():
-#    """Launched with `poetry run start` at root level"""
-#    uvicorn.run("lnbits.__main__:app")

--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -1,4 +1,5 @@
 import uvicorn
+
 from lnbits.settings import HOST, PORT
 
 


### PR DESCRIPTION
this pr fixes this issue: https://github.com/lnbits/lnbits-legend/issues/785

* removes click and uses env variables instead

if i am not mistaken, click in this context with `poetry run lnbits` would always use it's default values (127.0.0.1:5000), which for me is unexpected and inconsistent with our specified ENV variables.

to make things worse the server.py would start with the click default values, but our logger would log our ENV. so it basically showed the wrong PORT and HOST.