### PR TITLE
Poetry: uvicorn with .env and command line arguments

### DIFF
--- a/build.py
+++ b/build.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 LNBITS_PATH = path.dirname(path.realpath(__file__)) + "/lnbits"
 
+
 def get_js_vendored(prefer_minified: bool = False) -> List[str]:
     paths = get_vendored(".js", prefer_minified)
 
@@ -71,6 +72,7 @@ def get_vendored(ext: str, prefer_minified: bool = False) -> List[str]:
 def url_for_vendored(abspath: str) -> str:
     return "/" + os.path.relpath(abspath, LNBITS_PATH)
 
+
 def transpile_scss():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -79,6 +81,7 @@ def transpile_scss():
         with open(os.path.join(LNBITS_PATH, "static/scss/base.scss")) as scss:
             with open(os.path.join(LNBITS_PATH, "static/css/base.css"), "w") as css:
                 css.write(compile_string(scss.read()))
+
 
 def bundle_vendored():
     for getfiles, outputpath in [
@@ -96,15 +99,7 @@ def bundle_vendored():
 def build():
     transpile_scss()
     bundle_vendored()
-#    root = Path("lnbits/static/foo")
-#    root.mkdir(parents=True)
-#    root.joinpath("example.css").write_text("")
+
 
 if __name__ == "__main__":
-   build()
-
-#def build(setup_kwargs):
-#    """Build """
-#    transpile_scss()
-#    bundle_vendored()
-#    subprocess.run(["ls", "-la", "./lnbits/static"])
+    build()

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -4,7 +4,6 @@ import os
 import re
 import warnings
 
-import click
 from loguru import logger
 
 from .core import db as core_db
@@ -17,17 +16,6 @@ from .helpers import (
     url_for_vendored,
 )
 from .settings import LNBITS_PATH
-
-
-@click.command("migrate")
-def db_migrate():
-    asyncio.create_task(migrate_databases())
-
-
-@click.command("assets")
-def handle_assets():
-    transpile_scss()
-    bundle_vendored()
 
 
 def transpile_scss():

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -4,6 +4,7 @@ import os
 import re
 import warnings
 
+import click
 from loguru import logger
 
 from .core import db as core_db
@@ -16,6 +17,17 @@ from .helpers import (
     url_for_vendored,
 )
 from .settings import LNBITS_PATH
+
+
+@click.command("migrate")
+def db_migrate():
+    asyncio.create_task(migrate_databases())
+
+
+@click.command("assets")
+def handle_assets():
+    transpile_scss()
+    bundle_vendored()
 
 
 def transpile_scss():

--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -1,18 +1,13 @@
-import click
 import uvicorn
+from lnbits.settings import HOST, PORT
 
 
-@click.command()
-@click.option("--port", default="5000", help="Port to run LNBits on")
-@click.option("--host", default="127.0.0.1", help="Host to run LNBits on")
-def main(port, host):
+def main():
     """Launched with `poetry run lnbits` at root level"""
-    uvicorn.run("lnbits.__main__:app", port=port, host=host)
+    config = uvicorn.Config("lnbits.__main__:app", port=PORT, host=HOST)
+    server = uvicorn.Server(config)
+    server.run()
 
 
 if __name__ == "__main__":
     main()
-
-# def main():
-#    """Launched with `poetry run start` at root level"""
-#    uvicorn.run("lnbits.__main__:app")

--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -1,11 +1,40 @@
 import uvicorn
-
+import click
+import time
 from lnbits.settings import HOST, PORT
 
 
-def main():
+@click.command(
+    context_settings=dict(
+        ignore_unknown_options=True,
+        allow_extra_args=True,
+    )
+)
+@click.option("--port", default=PORT, help="Port to listen on")
+@click.option("--host", default=HOST, help="Host to run LNBits on")
+@click.option("--ssl-keyfile", default=None, help="SSL keyfile")
+@click.option("--ssl-certfile", default=None, help="SSL certificate")
+@click.pass_context
+def main(ctx, port: int, host: str, ssl_keyfile: str, ssl_certfile: str):
     """Launched with `poetry run lnbits` at root level"""
-    config = uvicorn.Config("lnbits.__main__:app", port=PORT, host=HOST)
+    # this ugly beast parses all command line arguments and passes them to the uvicorn server
+    d = dict(
+        [
+            (
+                item[0].strip("--").replace("-", "_"),
+                int(item[1]) if item[1].isdigit() else item[1],
+            )
+            for item in zip(*[iter(ctx.args)] * 2)
+        ]
+    )
+    config = uvicorn.Config(
+        "lnbits.__main__:app",
+        port=port,
+        host=host,
+        ssl_keyfile=ssl_keyfile,
+        ssl_certfile=ssl_certfile,
+        **d
+    )
     server = uvicorn.Server(config)
     server.run()
 

--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -19,7 +19,7 @@ from lnbits.settings import HOST, PORT
 @click.pass_context
 def main(ctx, port: int, host: str, ssl_keyfile: str, ssl_certfile: str):
     """Launched with `poetry run lnbits` at root level"""
-    # this ugly beast parses all command line arguments and passes them to the uvicorn server
+    # this beautiful beast parses all command line arguments and passes them to the uvicorn server
     d = dict(
         [
             (

--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -1,6 +1,8 @@
-import uvicorn
-import click
 import time
+
+import click
+import uvicorn
+
 from lnbits.settings import HOST, PORT
 
 
@@ -12,8 +14,8 @@ from lnbits.settings import HOST, PORT
 )
 @click.option("--port", default=PORT, help="Port to listen on")
 @click.option("--host", default=HOST, help="Host to run LNBits on")
-@click.option("--ssl-keyfile", default=None, help="SSL keyfile")
-@click.option("--ssl-certfile", default=None, help="SSL certificate")
+@click.option("--ssl-keyfile", default=None, help="Path to SSL keyfile")
+@click.option("--ssl-certfile", default=None, help="Path to SSL certificate")
 @click.pass_context
 def main(ctx, port: int, host: str, ssl_keyfile: str, ssl_certfile: str):
     """Launched with `poetry run lnbits` at root level"""

--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -1,4 +1,5 @@
 import uvicorn
+
 from lnbits.settings import HOST, PORT
 
 


### PR DESCRIPTION
* Respects `HOST` and `PORT` in `.env` if no arguments are given
* Parses all other arguments and makes them so that uvicorn gets it
* Removes old code from `build.py`

Examples:
```sh
~/git/lnbits-legend(branch:poetry-env*) » poetry run lnbits --help                                                                        cc@ddd
Usage: lnbits [OPTIONS]

  Launched with `poetry run lnbits` at root level

Options:
  --port INTEGER       Port to listen on
  --host TEXT          Host to run LNBits on
  --ssl-keyfile TEXT   SSL keyfile
  --ssl-certfile TEXT  SSL certificate
  --help               Show this message and exit.
```

And passing arbitrary arguments that will be piped to `uvicorn`:

```sh
poetry run lnbits --host 0.0.0.0 --port 5000 --ssl-keyfile ./localhost+2-key.pem --ssl-certfile ./localhost+2.pem
```

Fixes #833, #834, #785. Duplicate of #832.