### PR TITLE
Add NFC support to TPOS Extension

### DIFF
--- a/lnbits/extensions/tpos/crud.py
+++ b/lnbits/extensions/tpos/crud.py
@@ -47,4 +47,3 @@ async def get_tposs(wallet_ids: Union[str, List[str]]) -> List[TPoS]:
 
 async def delete_tpos(tpos_id: str) -> None:
     await db.execute("DELETE FROM tpos.tposs WHERE id = ?", (tpos_id,))
-    

--- a/lnbits/extensions/tpos/crud.py
+++ b/lnbits/extensions/tpos/crud.py
@@ -47,22 +47,4 @@ async def get_tposs(wallet_ids: Union[str, List[str]]) -> List[TPoS]:
 
 async def delete_tpos(tpos_id: str) -> None:
     await db.execute("DELETE FROM tpos.tposs WHERE id = ?", (tpos_id,))
-
-def bech32_decode(bech):
-    """tweaked version of bech32_decode that ignores length limitations"""
-    if (any(ord(x) < 33 or ord(x) > 126 for x in bech)) or (
-        bech.lower() != bech and bech.upper() != bech
-    ):
-        return
-    bech = bech.lower()
-    device = bech.rfind("1")
-    if device < 1 or device + 7 > len(bech):
-        return
-    if not all(x in bech32.CHARSET for x in bech[device + 1 :]):
-        return
-    hrp = bech[:device]
-    data = [bech32.CHARSET.find(x) for x in bech[device + 1 :]]
-    encoding = bech32.bech32_verify_checksum(hrp, data)
-    if encoding is None:
-        return
-    return bytes(bech32.convertbits(data[:-6], 5, 8, False))
+    

--- a/lnbits/extensions/tpos/models.py
+++ b/lnbits/extensions/tpos/models.py
@@ -23,3 +23,6 @@ class TPoS(BaseModel):
     @classmethod
     def from_row(cls, row: Row) -> "TPoS":
         return cls(**dict(row))
+
+class PayLnurlWData(BaseModel):
+    lnurl: str

--- a/lnbits/extensions/tpos/models.py
+++ b/lnbits/extensions/tpos/models.py
@@ -24,5 +24,6 @@ class TPoS(BaseModel):
     def from_row(cls, row: Row) -> "TPoS":
         return cls(**dict(row))
 
+
 class PayLnurlWData(BaseModel):
     lnurl: str

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -447,7 +447,7 @@
               self.nfcTagReading = false;
 
               this.$q.notify({
-                type: 'positive',
+                type: 'negative',
                 message: 'There was an error reading this NFC tag.'
               })
 
@@ -456,8 +456,15 @@
 
             ndef.onreading = ({message}) => { 
               //Decode NDEF data from tag
-              const record = message.records[0]
               const textDecoder = new TextDecoder('utf-8')
+      
+              const record = message.records.find(
+                (el) => {
+                  const payload = textDecoder.decode(el.data)
+                  return payload.toUpperCase().indexOf("LNURL") !== -1
+                } 
+              )
+
               const lnurl = textDecoder.decode(record.data)
 
               //User feedback, show loader icon
@@ -494,15 +501,15 @@
               '/pay',
             {
               lnurl: lnurl,
-            }, 
-            // {
-            //   body: {
-            //     lnurl: lnurl,
-            //   }
-            // }
+            },
           )
-          .then(function (response) {
-            console.log(response)
+          .then(response => {
+            if(!response.data.success) {
+              this.$q.notify({
+                type: 'negative',
+                message: response.data.detail
+              })
+            }
           })
       },
       getRates: function () {

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -174,6 +174,13 @@
             >
             {% endraw %}
           </h5>
+          <q-btn
+            outline
+            color="grey"
+            icon="nfc"
+            @click="readNfcTag()"
+            :disable="nfcTagReading"
+          ></q-btn>
         </div>
         <div class="row q-mt-lg">
           <q-btn v-close-popup flat color="grey" class="q-ml-auto">Close</q-btn>
@@ -281,6 +288,7 @@
         exchangeRate: null,
         stack: [],
         tipAmount: 0.0,
+        nfcTagReading: false,
         invoiceDialog: {
           show: false,
           data: null,
@@ -356,7 +364,7 @@
         this.showInvoice()
       },
       submitForm: function () {
-        if (this.tip_options) {
+        if (this.tip_options.length) {
           this.showTipModal()
         } else {
           this.showInvoice()
@@ -408,6 +416,84 @@
           })
           .catch(function (error) {
             LNbits.utils.notifyApiError(error)
+          })
+      },
+      readNfcTag: function() {
+        try {
+          const self = this
+
+          if (typeof NDEFReader == 'undefined') {
+            throw {
+              toString: function () {
+                return 'NFC not supported on this device or browser.'
+              }
+            }
+          }
+
+          const ndef = new NDEFReader()
+
+          this.nfcTagReading = true
+          this.$q.notify({
+            message: 'Tap your NFC tag to pay this invoice with LNURLw.'
+          })
+
+          ndef.addEventListener('readingerror', () => {
+            self.nfcTagReading = false;
+
+            this.$q.notify({
+              type: 'positive',
+              message: 'There was an error reading this NFC tag.'
+            })
+          })
+
+          ndef.addEventListener('reading', ({message, serialNumber}) => {
+              //Decode NDEF data from tag
+              const record = message.records[0]
+              const textDecoder = new TextDecoder('utf-8')
+              const lnurl = textDecoder.decode(record.data)
+
+              //User feedback, show loader icon
+              self.nfcTagReading = false;
+              self.payInvoice(lnurl)
+
+              this.$q.notify({
+                type: 'positive',
+                message: 'NFC tag read successfully.'
+              })
+          })
+
+          ndef.scan()
+        } catch (error) {
+          this.nfcTagReading = false
+          this.$q.notify({
+            type: 'negative',
+            message: error
+              ? error.toString()
+              : 'An unexpected error has occurred.'
+          })
+        }
+      },
+      payInvoice: function(lnurl) {
+        const self = this
+
+        return axios
+          .post(
+            '/tpos/api/v1/tposs/' +
+              self.tposId +
+              '/invoices/' +
+              self.invoiceDialog.data.payment_request + 
+              '/pay',
+            {
+              lnurl: lnurl,
+            }, 
+            {
+              body: {
+                lnurl: lnurl,
+              }
+            }
+          )
+          .then(function (response) {
+            console.log(response)
           })
       },
       getRates: function () {

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -418,7 +418,7 @@
             LNbits.utils.notifyApiError(error)
           })
       },
-      readNfcTag: function() {
+      readNfcTag: function () {
         try {
           const self = this
 
@@ -432,19 +432,19 @@
 
           const ndef = new NDEFReader()
 
-          const readerAbortController = new AbortController();
+          const readerAbortController = new AbortController()
           readerAbortController.signal.onabort = event => {
-            console.log("All NFC Read operations have been aborted.");
-          };  
+            console.log('All NFC Read operations have been aborted.')
+          }
 
           this.nfcTagReading = true
           this.$q.notify({
             message: 'Tap your NFC tag to pay this invoice with LNURLw.'
           })
 
-         return ndef.scan({ signal: readerAbortController.signal }).then(() => {
+          return ndef.scan({signal: readerAbortController.signal}).then(() => {
             ndef.onreadingerror = () => {
-              self.nfcTagReading = false;
+              self.nfcTagReading = false
 
               this.$q.notify({
                 type: 'negative',
@@ -454,21 +454,19 @@
               readerAbortController.abort()
             }
 
-            ndef.onreading = ({message}) => { 
+            ndef.onreading = ({message}) => {
               //Decode NDEF data from tag
               const textDecoder = new TextDecoder('utf-8')
-      
-              const record = message.records.find(
-                (el) => {
-                  const payload = textDecoder.decode(el.data)
-                  return payload.toUpperCase().indexOf("LNURL") !== -1
-                } 
-              )
+
+              const record = message.records.find(el => {
+                const payload = textDecoder.decode(el.data)
+                return payload.toUpperCase().indexOf('LNURL') !== -1
+              })
 
               const lnurl = textDecoder.decode(record.data)
 
               //User feedback, show loader icon
-              self.nfcTagReading = false;
+              self.nfcTagReading = false
               self.payInvoice(lnurl)
 
               this.$q.notify({
@@ -489,7 +487,7 @@
           })
         }
       },
-      payInvoice: function(lnurl) {
+      payInvoice: function (lnurl) {
         const self = this
 
         return axios
@@ -497,14 +495,14 @@
             '/tpos/api/v1/tposs/' +
               self.tposId +
               '/invoices/' +
-              self.invoiceDialog.data.payment_request + 
+              self.invoiceDialog.data.payment_request +
               '/pay',
             {
-              lnurl: lnurl,
-            },
+              lnurl: lnurl
+            }
           )
           .then(response => {
-            if(!response.data.success) {
+            if (!response.data.success) {
               this.$q.notify({
                 type: 'negative',
                 message: response.data.detail

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -495,11 +495,11 @@
             {
               lnurl: lnurl,
             }, 
-            {
-              body: {
-                lnurl: lnurl,
-              }
-            }
+            // {
+            //   body: {
+            //     lnurl: lnurl,
+            //   }
+            // }
           )
           .then(function (response) {
             console.log(response)

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -432,21 +432,29 @@
 
           const ndef = new NDEFReader()
 
+          const readerAbortController = new AbortController();
+          readerAbortController.signal.onabort = event => {
+            console.log("All NFC Read operations have been aborted.");
+          };  
+
           this.nfcTagReading = true
           this.$q.notify({
             message: 'Tap your NFC tag to pay this invoice with LNURLw.'
           })
 
-          ndef.addEventListener('readingerror', () => {
-            self.nfcTagReading = false;
+         return ndef.scan({ signal: readerAbortController.signal }).then(() => {
+            ndef.onreadingerror = () => {
+              self.nfcTagReading = false;
 
-            this.$q.notify({
-              type: 'positive',
-              message: 'There was an error reading this NFC tag.'
-            })
-          })
+              this.$q.notify({
+                type: 'positive',
+                message: 'There was an error reading this NFC tag.'
+              })
 
-          ndef.addEventListener('reading', ({message, serialNumber}) => {
+              readerAbortController.abort()
+            }
+
+            ndef.onreading = ({message}) => { 
               //Decode NDEF data from tag
               const record = message.records[0]
               const textDecoder = new TextDecoder('utf-8')
@@ -460,9 +468,10 @@
                 type: 'positive',
                 message: 'NFC tag read successfully.'
               })
-          })
 
-          ndef.scan()
+              readerAbortController.abort()
+            }
+          })
         } catch (error) {
           this.nfcTagReading = false
           this.$q.notify({

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -467,14 +467,12 @@
 
               //User feedback, show loader icon
               self.nfcTagReading = false
-              self.payInvoice(lnurl)
+              self.payInvoice(lnurl, readerAbortController)
 
               this.$q.notify({
                 type: 'positive',
                 message: 'NFC tag read successfully.'
               })
-
-              readerAbortController.abort()
             }
           })
         } catch (error) {
@@ -487,7 +485,7 @@
           })
         }
       },
-      payInvoice: function (lnurl) {
+      payInvoice: function (lnurl, readerAbortController) {
         const self = this
 
         return axios
@@ -508,6 +506,8 @@
                 message: response.data.detail
               })
             }
+
+            readerAbortController.abort()
           })
       },
       getRates: function () {

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -14,7 +14,7 @@
       <div class="row justify-center full-width">
         <div class="col-12 col-sm-8 col-md-6 col-lg-4 text-center">
           <h3 class="q-mb-md">{% raw %}{{ famount }}{% endraw %}</h3>
-          <h5 class="q-mt-none">
+          <h5 class="q-mt-none q-mb-sm">
             {% raw %}{{ fsat }}{% endraw %} <small>sat</small>
           </h5>
         </div>

--- a/lnbits/extensions/tpos/views_api.py
+++ b/lnbits/extensions/tpos/views_api.py
@@ -14,7 +14,7 @@ from lnbits.core.views.api import api_payment
 from lnbits.decorators import WalletTypeInfo, get_key_type, require_admin_key
 
 from . import tpos_ext
-from .crud import create_tpos, delete_tpos, get_tpos, get_tposs
+from .crud import create_tpos, delete_tpos, get_tpos, get_tposs, bech32_decode
 from .models import CreateTposData, PayLnurlWData
 
 
@@ -87,9 +87,14 @@ async def api_tpos_pay_invoice(
 ):
     tpos = await get_tpos(tpos_id)
 
-    #todo!
-    lnurl = lnurl_data.lnurl.replace("lnurlw://", "https://")
-    print("CALLING")
+    lnurl = lnurl_data.lnurl.replace("lnurlw://", "").replace("lightning://", "").replace("LIGHTNING://", "").replace("lightning:", "").replace("LIGHTNING:", "")
+    
+    if(lnurl.lower().startswith("lnurl")):
+        lnurl = bech32_decode(lnurl)
+    else:
+        lnurl = "https://" + lnurl
+
+    print('lnurl')
     print(lnurl)
 
     if not tpos:

--- a/lnbits/extensions/tpos/views_api.py
+++ b/lnbits/extensions/tpos/views_api.py
@@ -1,10 +1,9 @@
 from http import HTTPStatus
+
 import httpx
-
-from lnurl import decode as decode_lnurl
-
 from fastapi import Query
 from fastapi.params import Depends
+from lnurl import decode as decode_lnurl
 from loguru import logger
 from starlette.exceptions import HTTPException
 

--- a/lnbits/extensions/tpos/views_api.py
+++ b/lnbits/extensions/tpos/views_api.py
@@ -101,8 +101,7 @@ async def api_tpos_pay_invoice(
         try:
             r = await client.get(lnurl, follow_redirects=True)
             if r.is_error:
-                # lnurl_response = r.text
-                lnurl_response = "ERROR!"
+                lnurl_response = json.loads(r.text)
             else:
                 resp = json.loads(r.text)
                 if resp["tag"] != "withdrawRequest":
@@ -120,7 +119,6 @@ async def api_tpos_pay_invoice(
                         lnurl_response = "ERROR2!"
                     else:
                         resp2 = json.loads(r2.text)
-                        print(resp2)
                         lnurl_response = "OK"
         except (httpx.ConnectError, httpx.RequestError):
             print("BAD ERROR")

--- a/lnbits/extensions/tpos/views_api.py
+++ b/lnbits/extensions/tpos/views_api.py
@@ -81,7 +81,10 @@ async def api_tpos_create_invoice(
 
     return {"payment_hash": payment_hash, "payment_request": payment_request}
 
-@tpos_ext.post("/api/v1/tposs/{tpos_id}/invoices/{payment_request}/pay", status_code=HTTPStatus.OK)
+
+@tpos_ext.post(
+    "/api/v1/tposs/{tpos_id}/invoices/{payment_request}/pay", status_code=HTTPStatus.OK
+)
 async def api_tpos_pay_invoice(
     lnurl_data: PayLnurlWData, payment_request: str = None, tpos_id: str = None
 ):
@@ -92,9 +95,15 @@ async def api_tpos_pay_invoice(
             status_code=HTTPStatus.NOT_FOUND, detail="TPoS does not exist."
         )
 
-    lnurl = lnurl_data.lnurl.replace("lnurlw://", "").replace("lightning://", "").replace("LIGHTNING://", "").replace("lightning:", "").replace("LIGHTNING:", "")
-    
-    if(lnurl.lower().startswith("lnurl")):
+    lnurl = (
+        lnurl_data.lnurl.replace("lnurlw://", "")
+        .replace("lightning://", "")
+        .replace("LIGHTNING://", "")
+        .replace("lightning:", "")
+        .replace("LIGHTNING:", "")
+    )
+
+    if lnurl.lower().startswith("lnurl"):
         lnurl = decode_lnurl(lnurl)
     else:
         lnurl = "https://" + lnurl
@@ -110,16 +119,19 @@ async def api_tpos_pay_invoice(
                     lnurl_response = {"success": False, "detail": "Wrong tag type"}
                 else:
                     r2 = await client.get(
-                        resp['callback'],
+                        resp["callback"],
                         follow_redirects=True,
                         params={
-                            "k1": resp['k1'],
+                            "k1": resp["k1"],
                             "pr": payment_request,
-                        }
+                        },
                     )
                     resp2 = r2.json()
                     if r2.is_error:
-                        lnurl_response = {"success": False, "detail": "Error loading callback"}
+                        lnurl_response = {
+                            "success": False,
+                            "detail": "Error loading callback",
+                        }
                     elif resp2["status"] == "ERROR":
                         lnurl_response = {"success": False, "detail": resp2["reason"]}
                     else:


### PR DESCRIPTION
This PR adds NFC support to the TPOS extension, enabling payment to be collected via NFC tags that contain LNURLw strings (both raw and SUN authenticated via LNBits Bolt Cards extension).