### PR TITLE
stuck in retrying backend loop, fix issue #652

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -1,10 +1,10 @@
 import asyncio
 import importlib
 import logging
+import signal
 import sys
 import traceback
 import warnings
-import signal
 from http import HTTPStatus
 
 from fastapi import FastAPI, Request

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -121,7 +121,7 @@ def check_funding_source(app: FastAPI) -> None:
                 logger.info("Retrying connection to backend in 5 seconds...")
                 await asyncio.sleep(5)
             except:
-                logger.debug("check_wallet_status exited")
+                pass
         signal.signal(signal.SIGINT, original_sigint_handler)
         logger.info(
             f"✔️ Backend {WALLET.__class__.__name__} connected and with a balance of {balance} msat."

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -105,7 +105,7 @@ def check_funding_source(app: FastAPI) -> None:
         original_sigint_handler = signal.getsignal(signal.SIGINT)
 
         def signal_handler(signal, frame):
-            logger.debug("killing lnbits, Ctrl+C keyboard interrupt fired.")
+            logger.debug(f"SIGINT received, terminating LNbits.")
             sys.exit(1)
 
         signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
this fixes issue https://github.com/lnbits/lnbits-legend/issues/652

it works by using its own signal handler, overwriting the default one for the duration of the backend wallet initialisation. after the wallet is initialised, it restores the default uvicorn handler.
