### PR TITLE
fixing regtest, using lnbits again

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: abatilo/actions-poetry@v2.1.3
       - name: Setup Regtest
         run: |
+          docker build -t lnbits-legend .
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
           chmod +x ./tests
@@ -40,7 +41,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.xml            
+          file: ./coverage.xml
   LndWallet:
     runs-on: ubuntu-latest
     strategy:
@@ -55,6 +56,7 @@ jobs:
       - uses: abatilo/actions-poetry@v2.1.3
       - name: Setup Regtest
         run: |
+          docker build -t lnbits-legend .
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
           chmod +x ./tests
@@ -76,11 +78,11 @@ jobs:
           LND_GRPC_MACAROON: docker/data/lnd-1/data/chain/bitcoin/regtest/admin.macaroon
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
-          make test-real-wallet          
+          make test-real-wallet
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.xml          
+          file: ./coverage.xml
   CoreLightningWallet:
     runs-on: ubuntu-latest
     strategy:
@@ -95,6 +97,7 @@ jobs:
       - uses: abatilo/actions-poetry@v2.1.3
       - name: Setup Regtest
         run: |
+          docker build -t lnbits-legend .
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
           chmod +x ./tests


### PR DESCRIPTION
this pr adds building of the docker image into regtest tests again before using it inside the regtest for lnbits funding source tests
