### PR TITLE
return http error UNAUTHORIZED instead of BAD_REQUEST if key is missing

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: abatilo/actions-poetry@v2.1.3
       - name: Setup Regtest
         run: |
+          docker build -t lnbits-legend .
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
           chmod +x ./tests
@@ -40,7 +41,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.xml            
+          file: ./coverage.xml
   LndWallet:
     runs-on: ubuntu-latest
     strategy:
@@ -55,6 +56,7 @@ jobs:
       - uses: abatilo/actions-poetry@v2.1.3
       - name: Setup Regtest
         run: |
+          docker build -t lnbits-legend .
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
           chmod +x ./tests
@@ -76,11 +78,11 @@ jobs:
           LND_GRPC_MACAROON: docker/data/lnd-1/data/chain/bitcoin/regtest/admin.macaroon
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
-          make test-real-wallet          
+          make test-real-wallet
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.xml          
+          file: ./coverage.xml
   CoreLightningWallet:
     runs-on: ubuntu-latest
     strategy:
@@ -95,6 +97,7 @@ jobs:
       - uses: abatilo/actions-poetry@v2.1.3
       - name: Setup Regtest
         run: |
+          docker build -t lnbits-legend .
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
           chmod +x ./tests

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -262,7 +262,7 @@ async def api_payments_create(
         return await api_payments_create_invoice(invoiceData, wallet.wallet)
     else:
         raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST,
+            status_code=HTTPStatus.UNAUTHORIZED,
             detail="Invoice (or Admin) key required.",
         )
 


### PR DESCRIPTION
Tiny change that returns in `/api/v1/payments` an `HTTPStatus.UNAUTHORIZED` error if the key is missing. 

Same as in other instances where `require_invoice_key` is used.