### PR TITLE
Lnurlp: use `unhashed_description` instead of `description_hash`

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -75,7 +75,7 @@ def create_app(config_object="lnbits.settings") -> FastAPI:
         # Only the browser sends "text/html" request
         # not fail proof, but everything else get's a JSON response
 
-        if "text/html" in request.headers["accept"]:
+        if "text/html" in request.headers.get("accept"):
             return template_renderer().TemplateResponse(
                 "error.html",
                 {"request": request, "err": f"{exc.errors()} is not a valid UUID."},
@@ -185,7 +185,7 @@ def register_exception_handlers(app: FastAPI):
         traceback.print_exception(etype, err, tb)
         exc = traceback.format_exc()
 
-        if "text/html" in request.headers["accept"]:
+        if "text/html" in request.headers.get("accept"):
             return template_renderer().TemplateResponse(
                 "error.html", {"request": request, "err": err}
             )

--- a/lnbits/extensions/copilot/lnurl.py
+++ b/lnbits/extensions/copilot/lnurl.py
@@ -73,7 +73,7 @@ async def lnurl_callback(
         wallet_id=cp.wallet,
         amount=int(amount_received / 1000),
         memo=cp.lnurl_title,
-        description_hash=(
+        unhashed_description=(
             LnurlPayMetadata(json.dumps([["text/plain", str(cp.lnurl_title)]]))
         ).encode("utf-8"),
         extra={"tag": "copilot", "copilotid": cp.id, "comment": comment},

--- a/lnbits/extensions/livestream/lnurl.py
+++ b/lnbits/extensions/livestream/lnurl.py
@@ -90,7 +90,7 @@ async def lnurl_callback(
         wallet_id=ls.wallet,
         amount=int(amount_received / 1000),
         memo=await track.fullname(),
-        description_hash=(await track.lnurlpay_metadata()).encode("utf-8"),
+        unhashed_description=(await track.lnurlpay_metadata()).encode("utf-8"),
         extra={"tag": "livestream", "track": track.id, "comment": comment},
     )
 

--- a/lnbits/extensions/lnurldevice/lnurl.py
+++ b/lnbits/extensions/lnurldevice/lnurl.py
@@ -205,7 +205,7 @@ async def lnurl_callback(
         wallet_id=device.wallet,
         amount=lnurldevicepayment.sats / 1000,
         memo=device.title,
-        description_hash=(await device.lnurlpay_metadata()).encode("utf-8"),
+        unhashed_description=(await device.lnurlpay_metadata()).encode("utf-8"),
         extra={"tag": "PoS"},
     )
     lnurldevicepayment = await update_lnurldevicepayment(

--- a/lnbits/extensions/lnurlp/lnurl.py
+++ b/lnbits/extensions/lnurlp/lnurl.py
@@ -87,7 +87,7 @@ async def api_lnurl_callback(request: Request, link_id):
         wallet_id=link.wallet,
         amount=int(amount_received / 1000),
         memo=link.description,
-        description_hash=link.lnurlpay_metadata.encode("utf-8"),
+        unhashed_description=link.lnurlpay_metadata.encode("utf-8"),
         extra={
             "tag": "lnurlp",
             "link": link.id,

--- a/lnbits/extensions/offlineshop/lnurl.py
+++ b/lnbits/extensions/offlineshop/lnurl.py
@@ -73,7 +73,7 @@ async def lnurl_callback(request: Request, item_id: int):
             wallet_id=shop.wallet,
             amount=int(amount_received / 1000),
             memo=item.name,
-            description_hash=(await item.lnurlpay_metadata()).encode("utf-8"),
+            unhashed_description=(await item.lnurlpay_metadata()).encode("utf-8"),
             extra={"tag": "offlineshop", "item": item.id},
         )
     except Exception as exc:

--- a/lnbits/extensions/satsdice/lnurl.py
+++ b/lnbits/extensions/satsdice/lnurl.py
@@ -77,7 +77,7 @@ async def api_lnurlp_callback(
         wallet_id=link.wallet,
         amount=int(amount_received / 1000),
         memo="Satsdice bet",
-        description_hash=link.lnurlpay_metadata.encode("utf-8"),
+        unhashed_description=link.lnurlpay_metadata.encode("utf-8"),
         extra={"tag": "satsdice", "link": link.id, "comment": "comment"},
     )
 

--- a/lnbits/wallets/cln.py
+++ b/lnbits/wallets/cln.py
@@ -87,8 +87,10 @@ class CoreLightningWallet(Wallet):
         label = "lbl{}".format(random.random())
         msat: int = int(amount * 1000)
         try:
-            if description_hash:
-                raise Unsupported("description_hash")
+            if description_hash and not unhashed_description:
+                raise Unsupported(
+                    "'description_hash' unsupported by CLN, provide 'unhashed_description'"
+                )
             if unhashed_description and not self.supports_description_hash:
                 raise Unsupported("unhashed_description")
             r = self.ln.invoice(


### PR DESCRIPTION
Recently, the backends were update to support `unhashed_description` as well, so we can make CLN happy. 

This PR also changes how the rest of LNbits sends rather `unhashed_description` so it can work with CLN.

For LNURL stuff, provide `unhashed_description` instead of `description_hash`