### PR TITLE
Add docs for hosting LNBits on Fly.io (for free)

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -101,32 +101,49 @@ Fly.io is a docker container hosting platform that has a generous free tier. You
 
 First, sign up for an account at [Fly.io](https://fly.io) (no credit card required). 
 
-Then, install the Fly.io CLI onto your device [here](https://fly.io/docs/getting-started/installing-flyctl/). After install is complete, the command will output a command you should copy/paste/run to get `fly` into your `$PATH`. If you don't you'll have to call Fly from `~/.fly/bin/flyctl`.
+Then, install the Fly.io CLI onto your device [here](https://fly.io/docs/getting-started/installing-flyctl/). 
 
-Once installed, run these commands.
+After install is complete, the command will output a command you should copy/paste/run to get `fly` into your `$PATH`. Something like:
+
+```
+flyctl was installed successfully to /home/ubuntu/.fly/bin/flyctl
+Manually add the directory to your $HOME/.bash_profile (or similar)
+  export FLYCTL_INSTALL="/home/ubuntu/.fly"
+  export PATH="$FLYCTL_INSTALL/bin:$PATH"
+```
+
+You can either run those commands, then `source ~/.bash_profile` or, if you don't, you'll have to call Fly from `~/.fly/bin/flyctl`.
+
+Once installed, run the following commands.
 
 ```
 git clone https://github.com/lnbits/lnbits-legend.git
 cd lnbits-legend
 fly auth login
 [complete login process]
+fly launch
 ```
 
-Now, create a new file `fly.toml` and paste in the following. Be sure to replace `${PUT_YOUR_LNBITS_ENV_VARS_HERE}` with all relevant environment variables in `.env` or `.env.example`.
+You'll be prompted to enter an app name, region, postgres (choose no), deploy now (choose no).
 
-Environment variable strings should be quoted here, so if in `.env` you have `LNBITS_ENDPOINT=https://legend.lnbits.com` in `fly.toml` you should have `LNBITS_ENDPOINT="https://legend.lnbits.com"`.
+You'll now find a file in the directory called `fly.toml`. Open that file and modify/add the following settings. 
+
+Note: Be sure to replace `${PUT_YOUR_LNBITS_ENV_VARS_HERE}` with all relevant environment variables in `.env` or `.env.example`. Environment variable strings should be quoted here, so if in `.env` you have `LNBITS_ENDPOINT=https://legend.lnbits.com` in `fly.toml` you should have `LNBITS_ENDPOINT="https://legend.lnbits.com"`.
 
 Note: Don't enter secret environment variables here. Fly.io offers secrets (via the `fly secrets` command) that are exposed as environment variables in your runtime. So, for example, if using the LND_REST funding source, you can run `fly secrets set LND_REST_MACAROON=<hex_macaroon_data>`.
 
 ```
-app = "lnbits"
-kill_signal = "SIGINT"
+...
 kill_timeout = 30
+...
 
+...
 [mounts]
   source="lnbits_data"
   destination="/data"
+...
 
+...
 [env]
   HOST="127.0.0.1"
   PORT=5000
@@ -134,40 +151,21 @@ kill_timeout = 30
   LNBITS_DATA_FOLDER="/data"
   
   ${PUT_YOUR_LNBITS_ENV_VARS_HERE}
+...
 
-[experimental]
-  allowed_public_ports = []
-  auto_rollback = true
-
+...
 [[services]]
   internal_port = 5000
-  protocol = "tcp"
-
-  [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
-    type = "connections"
-
-  [[services.ports]]
-    force_https = true
-    handlers = ["http"]
-    port = 80
-
-  [[services.ports]]
-    handlers = ["tls", "http"]
-    port = 443
-
-  [[services.http_checks]]
-    grace_period = "60s"
+...
 ```
 
-Next, create a volume to store the sqlite database for LNBits.
+Next, create a volume to store the sqlite database for LNBits. Be sure to choose the same region for the volume that you chose earlier.
 
 ```
 fly volumes create lnbits_data --size 1
 ```
 
-You're ready to deploy! Run `fly launch` and follow the steps to finish deployment. You'll select a `region` (up to you, choose the same as you did for the storage volume previously created), `postgres` (choose no), `deploy` (choose yes).
+You're ready to deploy! Run `fly deploy` and follow the steps to finish deployment. You'll select a `region` (up to you, choose the same as you did for the storage volume previously created), `postgres` (choose no), `deploy` (choose yes).
 
 You can use `fly logs` to view the application logs, or `fly ssh console` to get a ssh shell in the running container.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -99,9 +99,9 @@ docker run --detach --publish 5000:5000 --name lnbits-legend --volume ${PWD}/.en
 
 Fly.io is a docker container hosting platform that has a generous free tier. You can host LNBits for free on Fly.io for personal use.
 
-First, sign up for an account at (Fly.io)[https://fly.io] (no credit card required). 
+First, sign up for an account at [Fly.io](https://fly.io) (no credit card required). 
 
-Then, install the Fly.io CLI onto your device (here)[https://fly.io/docs/getting-started/installing-flyctl/]
+Then, install the Fly.io CLI onto your device [here](https://fly.io/docs/getting-started/installing-flyctl/).
 
 Once installed, run these commands.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -95,6 +95,79 @@ mkdir data
 docker run --detach --publish 5000:5000 --name lnbits-legend --volume ${PWD}/.env:/app/.env --volume ${PWD}/data/:/app/data lnbits-legend
 ```
 
+## Option 5: Fly.io
+
+Fly.io is a docker container hosting platform that has a generous free tier. You can host LNBits for free on Fly.io for personal use.
+
+First, sign up for an account at (Fly.io)[https://fly.io] (no credit card required). 
+
+Then, install the Fly.io CLI onto your device (here)[https://fly.io/docs/getting-started/installing-flyctl/]
+
+Once installed, run these commands.
+
+```
+git clone https://github.com/lnbits/lnbits-legend.git
+cd lnbits-legend
+fly auth login
+[complete login process]
+```
+
+Now, create a new file `fly.toml` and paste in the following. Be sure to replace `${PUT_YOUR_LNBITS_ENV_VARS_HERE}` with all relevant environment variables in `.env` or `.env.example`.
+
+Note: Don't enter secret environment variables here. Fly.io offers secrets (via the `fly secrets` command) that are exposed as environment variables in your runtime. So, for example, if using the LND_REST funding source, you can run `fly secrets set LND_REST_MACAROON=<hex_macaroon_data>`.
+
+```
+app = "lnbits"
+kill_signal = "SIGINT"
+kill_timeout = 30
+
+[mounts]
+source="lnbits_data"
+destination="/data"
+
+[env]
+  HOST="127.0.0.1"
+  PORT=5000
+  LNBITS_FORCE_HTTPS=true
+  
+  ${PUT_YOUR_LNBITS_ENV_VARS_HERE}
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  internal_port = 5000
+  protocol = "tcp"
+
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.http_checks]]
+    grace_period = "60s"
+```
+
+Next, create a volume to store the sqlite database for LNBits.
+
+```
+fly volumes create lnbits_data --size 1
+```
+
+You're ready to deploy! Run `fly launch` and follow the steps to finish deployment. You'll select a `region` (up to you, choose the same as you did for the storage volume previously created), `postgres` (choose no), `deploy` (choose yes).
+
+You can use `fly logs` to view the application logs, or `fly ssh console` to get a ssh shell in the running container.
+
 ### Troubleshooting
 
 Problems installing? These commands have helped us install LNbits.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -129,6 +129,7 @@ destination="/data"
   HOST="127.0.0.1"
   PORT=5000
   LNBITS_FORCE_HTTPS=true
+  LNBITS_DATA_FOLDER="/data"
   
   ${PUT_YOUR_LNBITS_ENV_VARS_HERE}
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -114,6 +114,8 @@ fly auth login
 
 Now, create a new file `fly.toml` and paste in the following. Be sure to replace `${PUT_YOUR_LNBITS_ENV_VARS_HERE}` with all relevant environment variables in `.env` or `.env.example`.
 
+Environment variable strings should be quoted here, so if in `.env` you have `LNBITS_ENDPOINT=https://legend.lnbits.com` in `fly.toml` you should have `LNBITS_ENDPOINT="https://legend.lnbits.com"`.
+
 Note: Don't enter secret environment variables here. Fly.io offers secrets (via the `fly secrets` command) that are exposed as environment variables in your runtime. So, for example, if using the LND_REST funding source, you can run `fly secrets set LND_REST_MACAROON=<hex_macaroon_data>`.
 
 ```
@@ -122,8 +124,8 @@ kill_signal = "SIGINT"
 kill_timeout = 30
 
 [mounts]
-source="lnbits_data"
-destination="/data"
+  source="lnbits_data"
+  destination="/data"
 
 [env]
   HOST="127.0.0.1"

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -101,7 +101,7 @@ Fly.io is a docker container hosting platform that has a generous free tier. You
 
 First, sign up for an account at [Fly.io](https://fly.io) (no credit card required). 
 
-Then, install the Fly.io CLI onto your device [here](https://fly.io/docs/getting-started/installing-flyctl/).
+Then, install the Fly.io CLI onto your device [here](https://fly.io/docs/getting-started/installing-flyctl/). After install is complete, the command will output a command you should copy/paste/run to get `fly` into your `$PATH`. If you don't you'll have to call Fly from `~/.fly/bin/flyctl`.
 
 Once installed, run these commands.
 


### PR DESCRIPTION
Fly.io is a neat hosting provider that takes a docker container and runs it for you. They have a generous free tier that is enough to run LNBits w/ sqlite. This PR is just some docs on how to do it.