### PR TITLE
Add backend: ln.tips (LightningTipBot) wallet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ LNBITS_SITE_DESCRIPTION="Some description about your service, will display if ti
 LNBITS_THEME_OPTIONS="classic, bitcoin, freedom, mint, autumn, monochrome, salvador"
 # LNBITS_CUSTOM_LOGO="https://lnbits.com/assets/images/logo/logo.svg"
 
-# Choose from LNPayWallet, OpenNodeWallet, LntxbotWallet, ClicheWallet
+# Choose from LNPayWallet, OpenNodeWallet, LntxbotWallet, ClicheWallet, LnTipsWallet
 #             LndRestWallet, CoreLightningWallet, LNbitsWallet, SparkWallet, FakeWallet, EclairWallet
 LNBITS_BACKEND_WALLET_CLASS=VoidWallet
 # VoidWallet is just a fallback that works without any actual Lightning capabilities,
@@ -87,3 +87,7 @@ LNBITS_DENOMINATION=sats
 # EclairWallet
 ECLAIR_URL=http://127.0.0.1:8283
 ECLAIR_PASS=eclairpw
+
+# LnTipsWallet
+LNTIPS_API_KEY=LNTIPS_ADMIN_KEY
+LNTIPS_API_ENDPOINT=https://ln.tips

--- a/lnbits/wallets/__init__.py
+++ b/lnbits/wallets/__init__.py
@@ -1,5 +1,7 @@
 # flake8: noqa
 
+
+from .lntips import LnTipsWallet
 from .cliche import ClicheWallet
 from .cln import CoreLightningWallet  # legacy .env support
 from .cln import CoreLightningWallet as CLightningWallet

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -33,7 +33,7 @@ class LNbitsWallet(Wallet):
         async with httpx.AsyncClient() as client:
             try:
                 r = await client.get(
-                    url=f"{self.endpoint}/api/v1/wallet", headers=self.key, timeout=15
+                    url=f"{self.endpoint}/api/v1/balance", headers=self.key, timeout=15
                 )
             except Exception as exc:
                 return StatusResponse(


### PR DESCRIPTION
Adds backend for new [ln.tips](ln.tips) API for LightningTipBot. Enter `/api` to see your API keys.