### PR TITLE
change docker image name for regtest tests

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: abatilo/actions-poetry@v2.1.3
       - name: Setup Regtest
         run: |
-          docker build -t lnbits-legend .
+          docker build -t lnbitsdocker/lnbits-legend .
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
           chmod +x ./tests
@@ -56,7 +56,7 @@ jobs:
       - uses: abatilo/actions-poetry@v2.1.3
       - name: Setup Regtest
         run: |
-          docker build -t lnbits-legend .
+          docker build -t lnbitsdocker/lnbits-legend .
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
           chmod +x ./tests
@@ -97,7 +97,7 @@ jobs:
       - uses: abatilo/actions-poetry@v2.1.3
       - name: Setup Regtest
         run: |
-          docker build -t lnbits-legend .
+          docker build -t lnbitsdocker/lnbits-legend .
           git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
           cd docker
           chmod +x ./tests


### PR DESCRIPTION
this helps simplifying the regtest setup.
if we do not want to rebuild the docker image.

it is basically removing this comment, https://github.com/lnbits/legend-regtest-enviroment/blob/main/docker-compose.yml#L11
