### PR TITLE
Hide NFC button if device does not support NFC

### DIFF
--- a/lnbits/extensions/lnurlp/static/js/index.js
+++ b/lnbits/extensions/lnurlp/static/js/index.js
@@ -36,6 +36,7 @@ new Vue({
         }
       },
       nfcTagWriting: false,
+      nfcSupported: (typeof NDEFReader != 'undefined'),
       formDialog: {
         show: false,
         fixedAmount: true,

--- a/lnbits/extensions/lnurlp/static/js/index.js
+++ b/lnbits/extensions/lnurlp/static/js/index.js
@@ -36,7 +36,7 @@ new Vue({
         }
       },
       nfcTagWriting: false,
-      nfcSupported: (typeof NDEFReader != 'undefined'),
+      nfcSupported: typeof NDEFReader != 'undefined',
       formDialog: {
         show: false,
         fixedAmount: true,

--- a/lnbits/extensions/lnurlp/templates/lnurlp/index.html
+++ b/lnbits/extensions/lnurlp/templates/lnurlp/index.html
@@ -306,6 +306,7 @@
           icon="nfc"
           @click="writeNfcTag(qrCodeDialog.data.lnurl)"
           :disable="nfcTagWriting"
+          v-if="nfcSupported"
           ><q-tooltip>Write to NFC</q-tooltip>
         </q-btn>
         <q-btn

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -296,7 +296,7 @@
         stack: [],
         tipAmount: 0.0,
         nfcTagReading: false,
-        nfcSupported: (typeof NDEFReader != 'undefined'),
+        nfcSupported: typeof NDEFReader != 'undefined',
         invoiceDialog: {
           show: false,
           data: null,

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -180,6 +180,7 @@
             icon="nfc"
             @click="readNfcTag()"
             :disable="nfcTagReading"
+            v-if="nfcSupported"
           ></q-btn>
         </div>
         <div class="row q-mt-lg">
@@ -295,6 +296,7 @@
         stack: [],
         tipAmount: 0.0,
         nfcTagReading: false,
+        nfcSupported: (typeof NDEFReader != 'undefined'),
         invoiceDialog: {
           show: false,
           data: null,

--- a/lnbits/extensions/withdraw/static/js/index.js
+++ b/lnbits/extensions/withdraw/static/js/index.js
@@ -57,7 +57,7 @@ new Vue({
         }
       },
       nfcTagWriting: false,
-      nfcSupported: (typeof NDEFReader != 'undefined'),
+      nfcSupported: typeof NDEFReader != 'undefined',
       formDialog: {
         show: false,
         secondMultiplier: 'seconds',

--- a/lnbits/extensions/withdraw/static/js/index.js
+++ b/lnbits/extensions/withdraw/static/js/index.js
@@ -57,6 +57,7 @@ new Vue({
         }
       },
       nfcTagWriting: false,
+      nfcSupported: (typeof NDEFReader != 'undefined'),
       formDialog: {
         show: false,
         secondMultiplier: 'seconds',

--- a/lnbits/extensions/withdraw/templates/withdraw/index.html
+++ b/lnbits/extensions/withdraw/templates/withdraw/index.html
@@ -428,6 +428,7 @@
           icon="nfc"
           @click="writeNfcTag(qrCodeDialog.data.lnurl)"
           :disable="nfcTagWriting"
+          v-if="nfcSupported"
           ><q-tooltip>Write to NFC</q-tooltip></q-btn
         >
         <q-btn


### PR DESCRIPTION
This PR resolves issue #907 . We want to hide the NFC button if the device does not support NFC in the lnurlp, lnurlw, and tpos extensions.