### PR TITLE
Fix/tpos dismiss btn

### DIFF
--- a/lnbits/extensions/tpos/templates/tpos/index.html
+++ b/lnbits/extensions/tpos/templates/tpos/index.html
@@ -138,8 +138,9 @@
           hide-dropdown-icon
           input-debounce="0"
           new-value-mode="add-unique"
-          label="Tip % Options"
-        ></q-select>
+          label="Tip % Options (hit enter to add values)"
+          ><q-tooltip>Hit enter to add values</q-tooltip></q-select
+        >
         <div class="row q-mt-lg">
           <q-btn
             unelevated

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -175,7 +175,6 @@
             {% endraw %}
           </h5>
           <q-btn
-            v-if="hasNFC"
             outline
             color="grey"
             icon="nfc"
@@ -546,8 +545,6 @@
       setInterval(function () {
         getRates()
       }, 120000)
-
-      this.hasNFC = 'NDEFReader' in window
     }
   })
 </script>

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -253,7 +253,7 @@
         name="check"
         transition-show="fade"
         class="text-light-green"
-        style="font-size: 40em"
+        style="font-size: min(90vw, 40em)"
       ></q-icon>
     </q-dialog>
   </q-page>
@@ -413,9 +413,19 @@
                     dialog.show = false
 
                     self.complete.show = true
-                    setTimeout(function () {
-                      self.complete.show = false
-                    }, 5000)
+                    self.$q.notify({
+                      type: 'positive',
+                      message: 'Sats received, thanks!',
+                      icon: 'thumb_up',
+                      timeout: 0,
+                      actions: [
+                        {
+                          label: 'Dismiss',
+                          color: 'white',
+                          handler: () => (self.complete.show = false)
+                        }
+                      ]
+                    })
                   }
                 })
             }, 3000)

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -414,19 +414,6 @@
                     dialog.show = false
 
                     self.complete.show = true
-                    self.$q.notify({
-                      type: 'positive',
-                      message: 'Sats received, thanks!',
-                      icon: 'thumb_up',
-                      timeout: 0,
-                      actions: [
-                        {
-                          label: 'Dismiss',
-                          color: 'white',
-                          handler: () => (self.complete.show = false)
-                        }
-                      ]
-                    })
                   }
                 })
             }, 3000)

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -175,6 +175,7 @@
             {% endraw %}
           </h5>
           <q-btn
+            v-if="hasNFC"
             outline
             color="grey"
             icon="nfc"
@@ -294,6 +295,7 @@
         exchangeRate: null,
         stack: [],
         tipAmount: 0.0,
+        hasNFC: false,
         nfcTagReading: false,
         invoiceDialog: {
           show: false,
@@ -370,7 +372,7 @@
         this.showInvoice()
       },
       submitForm: function () {
-        if (this.tip_options.length) {
+        if (this.tip_options && this.tip_options.length) {
           this.showTipModal()
         } else {
           this.showInvoice()
@@ -544,6 +546,8 @@
       setInterval(function () {
         getRates()
       }, 120000)
+
+      this.hasNFC = 'NDEFReader' in window
     }
   })
 </script>


### PR DESCRIPTION
Removed the timeout on the green checkmark after payment and added a dismissable notification for the payment. Either dismiss the notification to remove the checkmark (and the notification), or even if the checkmark goes away (it closes if the screen is clicked) the notification stays and needs to be manually clicked!

![pos](https://user-images.githubusercontent.com/12083186/188434308-3ee72b2c-56cf-4a93-8dc8-ff68c89f0d9a.png)
