### PR TITLE
fix: type can be `None` due to migration issue

### DIFF
--- a/lnbits/extensions/watchonly/models.py
+++ b/lnbits/extensions/watchonly/models.py
@@ -19,7 +19,7 @@ class WalletAccount(BaseModel):
     title: str
     address_no: int
     balance: int
-    type: str = ""
+    type: Optional[str] = ""
     network: str = "Mainnet"
 
     @classmethod


### PR DESCRIPTION
Column `type` has no default value (eg: `''`).
The model must accept `None`.