### PR TITLE
fix for uppercase QR

### DIFF
--- a/lnbits/core/static/js/wallet.js
+++ b/lnbits/core/static/js/wallet.js
@@ -369,9 +369,9 @@ new Vue({
     decodeRequest: function () {
       this.parse.show = true
       let req = this.parse.data.request.toLowerCase()
-      if (this.parse.data.request.startsWith('lightning:')) {
+      if (this.parse.data.request.toLowerCase().startsWith('lightning:')) {
         this.parse.data.request = this.parse.data.request.slice(10)
-      } else if (this.parse.data.request.startsWith('lnurl:')) {
+      } else if (this.parse.data.request.toLowerCase().startsWith('lnurl:')) {
         this.parse.data.request = this.parse.data.request.slice(6)
       } else if (req.indexOf('lightning=lnurl1') !== -1) {
         this.parse.data.request = this.parse.data.request


### PR DESCRIPTION
Got a QR (LNURLw) from General Bytes ATM which was upper-cased like `LIGHTNING:LNURL1XXXX` and ended up with the `Malformed request: checksum is incorrect` message from the invoice decoder when scanning it. So here's a little fix. 